### PR TITLE
fix input[type="text"] and textarea styles in safari mobile

### DIFF
--- a/build/98.css
+++ b/build/98.css
@@ -323,6 +323,10 @@ input[type="text"] {
     inset 2px 2px #0a0a0a;
   background-color: #ffffff;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 select {
@@ -333,6 +337,10 @@ select {
     inset 2px 2px #0a0a0a;
   background-color: #ffffff;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 textarea {
@@ -343,6 +351,10 @@ textarea {
     inset 2px 2px #0a0a0a;
   background-color: #ffffff;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 input[type="text"],

--- a/docs/98.css
+++ b/docs/98.css
@@ -323,6 +323,10 @@ input[type="text"] {
     inset 2px 2px #0a0a0a;
   background-color: #ffffff;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 select {
@@ -333,6 +337,10 @@ select {
     inset 2px 2px #0a0a0a;
   background-color: #ffffff;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 textarea {
@@ -343,6 +351,10 @@ textarea {
     inset 2px 2px #0a0a0a;
   background-color: #ffffff;
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 input[type="text"],

--- a/style.css
+++ b/style.css
@@ -315,6 +315,10 @@ textarea {
   box-shadow: var(--border-field);
   background-color: var(--button-highlight);
   box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
 }
 
 input[type="text"],


### PR DESCRIPTION
Text fields were not rendering correctly in Safari Mobile as described [here](https://github.com/jdan/98.css/issues/5)

Just added

```
  -webkit-appearance: none;
  -moz-appearance: none;
  appearance: none;
  border-radius: 0;
```

to `input[type="text"],
select,
textarea` in `/style.css`

and ran `npm run build`