### PR TITLE
Adding tabs

### DIFF
--- a/style.css
+++ b/style.css
@@ -58,6 +58,11 @@
   --border-field: inset -1px -1px var(--button-highlight),
     inset 1px 1px var(--button-shadow), inset -2px -2px var(--button-face),
     inset 2px 2px var(--window-frame);
+
+  --border-tab: inset -1px 0 var(--window-frame),
+    inset 1px 1px var(--button-highlight),
+    inset -2px 0 var(--button-shadow),
+    inset 2px 2px var(--button-face)
 }
 
 @font-face {
@@ -528,4 +533,46 @@ summary:focus {
 ::-webkit-scrollbar-button:horizontal:end {
   width: 16px;
   background-image: svg-load("./icon/button-right.svg");
+}
+
+menu.tabs {
+  position: relative;
+  margin: 0 0 -2px 0;
+  text-indent: 0;
+  list-style-type: none;
+  display: flex;
+  padding-left: 3px;
+}
+
+menu.tabs li {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  box-shadow: var(--border-tab);
+  z-index: 1;
+}
+menu.tabs > li.active {
+  padding-bottom: 2px;
+  margin-top: -2px;
+  background-color: var(--surface);
+  position: relative;
+  z-index: 8;
+  margin-left: -3px;
+}
+
+menu.tabs > li > a {
+  display: block;
+  color: #222;
+  margin: 6px;
+  text-decoration: none;
+}
+menu.tabs > li.active > a:focus {
+  outline: none;
+}
+menu.tabs > li > a:focus {
+  outline: 1px dotted #222;
+}
+
+menu.tabs.justified > li {
+  flex-grow: 1;
+  text-align: center;
 }

--- a/style.css
+++ b/style.css
@@ -535,7 +535,12 @@ summary:focus {
   background-image: svg-load("./icon/button-right.svg");
 }
 
-menu.tabs {
+.window[role=tabpanel] {
+  position: relative;
+  z-index: 2;
+}
+
+menu[role=tablist] {
   position: relative;
   margin: 0 0 -2px 0;
   text-indent: 0;
@@ -544,13 +549,14 @@ menu.tabs {
   padding-left: 3px;
 }
 
-menu.tabs li {
+menu[role=tablist] > li {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   box-shadow: var(--border-tab);
   z-index: 1;
 }
-menu.tabs > li.active {
+
+menu[role=tablist] > li[aria-selected] {
   padding-bottom: 2px;
   margin-top: -2px;
   background-color: var(--surface);
@@ -559,20 +565,20 @@ menu.tabs > li.active {
   margin-left: -3px;
 }
 
-menu.tabs > li > a {
+menu[role=tablist] > li > a {
   display: block;
   color: #222;
   margin: 6px;
   text-decoration: none;
 }
-menu.tabs > li.active > a:focus {
+menu[role=tablist] > li[aria-selected] > a:focus {
   outline: none;
 }
-menu.tabs > li > a:focus {
+menu[role=tablist] > li > a:focus {
   outline: 1px dotted #222;
 }
 
-menu.tabs.justified > li {
+menu[role=tablist].justified > li {
   flex-grow: 1;
   text-align: center;
 }


### PR DESCRIPTION
This is a first try at reproducing W98 tabs - #21

I looked at how tabs behaves in W98 and it looks like normal tabs are justified left.
Then only when tabs become multi-rows then they are justified in full width. 
Also i think i remember the row where belongs the active tabs is always pulled down, isn't it ?

Here are some single row tabs
![Screenshot 2020-04-22 at 20 58 46](https://user-images.githubusercontent.com/24324122/80023114-56601e00-84dd-11ea-9311-68ccf691ee9b.png)
![Screenshot 2020-04-22 at 20 59 13](https://user-images.githubusercontent.com/24324122/80023120-58c27800-84dd-11ea-9aa7-2c08b626f14e.png)

And some multi-rows tabs
![Screenshot 2020-04-22 at 20 56 51](https://user-images.githubusercontent.com/24324122/80023197-77287380-84dd-11ea-8a49-baba59d5550d.png)
![Screenshot 2020-04-22 at 20 57 58](https://user-images.githubusercontent.com/24324122/80023200-77c10a00-84dd-11ea-9142-f3375ae5142b.png)

Here is the HTML
```HTML
<menu class="tabs">
  <li class="active"><a href="#">Desktop</a></li>
  <li><a href="#">My computer</a></li>
  <li><a href="#">Control panel</a></li>
  <li><a href="#">Devices manager</a></li>
  <li><a href="#">Hardware profiles</a></li>
  <li><a href="#">Performance</a></li>
</menu>
<div class="window">
  <div class="window-body">
    <!-- the tab content -->
  </div>
</div>
```

For multi-row you can use `.tabs.justified`.
Although now i think it should be called `.multirows`.

Given i tried to reuse the `.window` as a tab container i had to find some hacks and made use of z-index in order to pull the active tab upfront and cover the container borders.
Is there a reason why the borders are made with box-shadows instead of real borders ?

Best 🙂 