### PR TITLE
Add `:active` state to radio and checkbox inputs

### DIFF
--- a/style.css
+++ b/style.css
@@ -290,6 +290,10 @@ input[type="radio"] + label::before {
   background: svg-load("./icon/radio-border.svg");
 }
 
+input[type="radio"]:active + label::before {
+  background: svg-load("./icon/radio-border-disabled.svg");
+}
+
 input[type="radio"]:checked + label::after {
   content: "";
   display: block;
@@ -329,6 +333,10 @@ input[type="checkbox"] + label::before {
   background: var(--button-highlight);
   box-shadow: var(--border-field);
   margin-right: var(--radio-label-spacing);
+}
+
+input[type="checkbox"]:active + label::before {
+  background: var(--surface);
 }
 
 input[type="checkbox"]:checked + label::after {


### PR DESCRIPTION
Fix issue #11. 

Could reuse the existing SVG and color variable for both input active state.


**Original Windows 98**
![Kapture 2020-04-25 at 20 04 46](https://user-images.githubusercontent.com/8354774/80287234-c0243600-8730-11ea-8c12-99a227c9c5b4.gif)
https://copy.sh/v86/?profile=windows98

**98.css**
![Kapture 2020-04-25 at 20 07 36](https://user-images.githubusercontent.com/8354774/80287236-c31f2680-8730-11ea-8b02-8d5e2d61e937.gif)
![Kapture 2020-04-25 at 20 08 48](https://user-images.githubusercontent.com/8354774/80287237-c31f2680-8730-11ea-9c1c-47af3659a68c.gif)