### PR TITLE
bugfix: show relevant scrollbar buttons on osx

### DIFF
--- a/style.css
+++ b/style.css
@@ -527,6 +527,13 @@ summary:focus {
   box-shadow: var(--border-raised-outer), var(--border-raised-inner);
 }
 
+::-webkit-scrollbar-button:horizontal:start:decrement,
+::-webkit-scrollbar-button:horizontal:end:increment,
+::-webkit-scrollbar-button:vertical:start:decrement,
+::-webkit-scrollbar-button:vertical:end:increment {
+  display: block;
+}
+
 ::-webkit-scrollbar-button:vertical:start {
   height: 17px;
   background-image: svg-load("./icon/button-up.svg");


### PR DESCRIPTION
Fixes #57, implementing [this solution](https://stackoverflow.com/questions/41249083/scrollbar-css-buttons-not-showing-on-macos).

![Screen Shot 2020-04-25 at 5 32 39 PM](https://user-images.githubusercontent.com/15032398/80294135-16867a00-871b-11ea-9961-b02a8f3314fa.png)
