### PR TITLE
Add support for expandable tree view

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -102,7 +102,9 @@ summary {
   display: inline;
 }
 
-summary::-webkit-details-marker { display: none; }
+summary::-webkit-details-marker {
+    display: none;
+}
 
 details[open] summary {
   margin-bottom: 8px;

--- a/docs/docs.css
+++ b/docs/docs.css
@@ -102,6 +102,8 @@ summary {
   display: inline;
 }
 
+summary::-webkit-details-marker { display: none; }
+
 details[open] summary {
   margin-bottom: 8px;
 }

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -586,6 +586,10 @@
           (no class needed on these). This will provide them with a nice dotted
           border and indentation to illustrate the structure of the tree.
         </p>
+        <p>
+          To create expandable sections, wrap child lists inside of
+          <code>details</code> elements.
+        </p>
 
         <%- example(`
           <ul class="tree-view">
@@ -600,10 +604,33 @@
               </ul>
             </li>
             <li>
-              JavaScript
-              <ul>
-                <li>Avoid at all costs</li>
-              </ul>
+              <details open>
+                <summary>JavaScript</summary>
+                <ul>
+                  <li>Avoid at all costs</li>
+                  <li>
+                    <details>
+                      <summary>Unless</summary>
+                      <ul>
+                        <li>Avoid</li>
+                        <li>
+                          <details>
+                            <summary>At</summary>
+                            <ul>
+                              <li>Avoid</li>
+                              <li>At</li>
+                              <li>All</li>
+                              <li>Cost</li>
+                            </ul>
+                          </details>
+                        </li>
+                        <li>All</li>
+                        <li>Cost</li>
+                      </ul>
+                    </details>
+                  </li>
+                </ul>
+              </details>
             </li>
             <li>HTML</li>
             <li>Special Thanks</li>

--- a/style.css
+++ b/style.css
@@ -490,6 +490,38 @@ ul.tree-view ul > li:last-child::after {
   background: var(--button-highlight);
 }
 
+ul.tree-view details {
+  margin-top: 0;
+}
+
+ul.tree-view details[open] summary {
+  margin-bottom: 0;
+}
+
+ul.tree-view ul details > summary:before {
+  margin-left: -22px;
+  position: relative;
+  z-index: 1;
+}
+
+ul.tree-view details > summary:before {
+  text-align: center;
+  display: block;
+  float: left;
+  content: '+';
+  border: 1px solid #808080;
+  width: 8px;
+  height: 9px;
+  line-height: 9px;
+  margin-right: 5px;
+  padding-left: 1px;
+  background-color: #fff;
+}
+
+ul.tree-view details[open] > summary:before {
+  content: '-'
+}
+
 pre {
   display: block;
   background: var(--button-highlight);


### PR DESCRIPTION
The spec for expandable tree view wasn't very clear as the images on the book don't show a mixed state in the tree view, and currently there also isn't support for icons. 

I wonder if regular tree view and expandable tree aren't supposed to be mixed? Regardless, this is a step forward.

|before|after|
|-|-|
|<img width="337" alt="non-expandable tree view" src="https://user-images.githubusercontent.com/1153134/80330349-f0dc9c00-8812-11ea-91d2-b2d129065c71.png">|<img width="443" alt="tree view with expandable icons using details element" src="https://user-images.githubusercontent.com/1153134/80330337-e91cf780-8812-11ea-9dd4-b2dcc1c44782.png">|

The minus and plus signs are probably better as icons. 

⚠️ I am not sure if the current reset styles on `summary` is intentional. It's currently inconsistent between Chrome (not reset) and Firefox (reset). Here I added the reset style, but am also happy to move them to `.tree-view`. 