### PR TITLE
Added progress bars (ProgressIndicator)

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -39,6 +39,7 @@
             </ul>
           </li>
           <li><a href="#tree-view">TreeView</a></li>
+          <li><a href="#progress-indicator">Progress Indicator</a></li>
         </ul>
       </li>
       <li><a href="#issues-contributing-etc">Issues, Contributing, etc.</a></li>
@@ -608,6 +609,35 @@
             <li>HTML</li>
             <li>Special Thanks</li>
           </ul>
+        `) %>
+      </div>
+    </section>
+
+    <section class="component">
+      <h3 id="progress-indicator">Progress Indicator</h3>
+      <div>
+        <blockquote>
+          A <em>ProgressIndicator</em> is a control, also known as a <em>progress bar control</em>, you can use to show the percentage of completion of a lengthy operation.
+
+          <footer>
+            &mdash; Microsoft Windows User Experience p. 142
+          </footer>
+        </blockquote>
+
+        <p>
+          The ProgressIndicator component supports two types of bars. Both are deterministic, which means that you should give it a <code>value</code> parameter. Indeterministic progress bars are not supported, yet.
+        </p>
+
+        <p>
+          There are two types of progress bars: continuous and block. The continuous doesn't require any further configuration. The block bar does require a class of <code>progress-bar-block</code>.
+        </p>
+
+        <%- example(`
+          <progress value="50" max="100"></progress>
+        `) %>
+
+        <%- example(`
+          <progress class="progress-bar-block" value="70" max="100"></progress>
         `) %>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -507,6 +507,38 @@ summary:focus {
   outline: 1px dotted #000000;
 }
 
+progress {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 280px;
+  height: 16px;
+  box-shadow: var(--border-field);
+}
+
+progress::-webkit-progress-bar {
+  background: var(--surface);
+  box-shadow: var(--border-field);
+}
+
+progress[value]::-webkit-progress-value,
+progress[value]::-moz-progress-bar {
+  background-color: var(--dialog-blue);
+  box-shadow: var(--border-field);
+}
+
+progress[value].progress-bar-block::-webkit-progress-value,
+progress[value].progress-bar-block::-moz-progress-bar {
+  background: repeating-linear-gradient(to right,
+    var(--dialog-blue),
+    var(--dialog-blue) 4px,
+    var(--surface) 4px,
+    var(--surface) 8px,
+    var(--dialog-blue) 8px,
+    var(--dialog-blue) 12px
+  );
+}
+
 ::-webkit-scrollbar {
   width: 16px;
 }


### PR DESCRIPTION
**When merged this pull request will:**
- Add two types of deterministic progress bars (continuous and block) with documentation.
- Resolve #18.

:warning:  Issues:
- The border inset, inside the progress bar itself, on the right side has a white line, which shouldn't be there.
- The block progress bar has a weird spacing issue on the first block.
These issues are beyond my ability to currently resolve them, so someone else could take a look at it.

Testing:
- Tested in Chrome v80 and Firefox v75 on Ubuntu.

Example:
![example](https://user-images.githubusercontent.com/1590711/80357687-03db8480-8884-11ea-9e92-9ee1b7af779f.png)

References:
- [Comparsion of progress bars](https://wyday.com/windows-7-progress-bar/images/scrnshots/2000.xp.vista.7.pbs.png)
- [Windows User Experience manual p. 142](https://www.ics.uci.edu/~kobsa/courses/ICS104/course-notes/Microsoft_WindowsGuidelines.pdf)