### PR TITLE
Convert SourceMapGenerator to string in build script

### DIFF
--- a/build.js
+++ b/build.js
@@ -28,7 +28,7 @@ function buildCSS() {
     .then((result) => {
       mkdirp.sync("dist");
       fs.writeFileSync("dist/98.css", result.css);
-      fs.writeFileSync("dist/98.css.map", result.map);
+      fs.writeFileSync("dist/98.css.map", result.map.toString());
     });
 }
 


### PR DESCRIPTION
On node 14, build script fails with error because [fs.writeFileSync(file, data[, options])](https://nodejs.org/api/fs.html#fs_fs_writefilesync_file_data_options) received instance of `SourceMapGenerator`.

Screenshot:
![node_14](https://user-images.githubusercontent.com/34798085/80562046-af194480-8a10-11ea-8f33-e9f6aee5fc4f.png)

This solution works on older versions.