### PR TITLE
simplify code contributions by fully automating the dev setup

### DIFF
--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,6 @@
+tasks:
+  - init: npm install && npm run build
+    command: npm run start
+ports:
+  - port: 3000
+    onOpen: open-preview

--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Here is an example of [98.css being used with React](https://codesandbox.io/s/ob
 
 Refer to the [documentation page](https://jdan.github.io/98.css/) for specific instructions on this library's components.
 
+### Online one-click setup for Contributing
+
+Contribute to 98.css using a fully featured online development environment that will automatically: clone the repo, install the dependencies and start the webserver.
+
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/from-referrer/)
+
 ### Developing
 
 First, run `npm install`.


### PR DESCRIPTION
Hi! 

This Pr simplifies code contributions by fully automating the dev setup with Gitpod(an online VS-Code like IDE). With a single click, it'll launch a workspace and automatically:

- clone the 98.css repo.
- install the dependencies.
- run `npm run build`
- start the webserver.

so that anyone interested in contributing can start straight away without any friction.

![image](https://user-images.githubusercontent.com/46004116/80587088-6624b880-8a2f-11ea-9775-70bab73728a5.png)
 
You can give it a try on my fork of the repo via the following link:

https://gitpod.io/#https://github.com/nisarhassan12/98.css

