### PR TITLE
Add slider

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -30,6 +30,7 @@
           <li><a href="#option-button">OptionButton</a></li>
           <li><a href="#group-box">GroupBox</a></li>
           <li><a href="#text-box">TextBox</a></li>
+          <li><a href="#slider">Slider</a></li>
           <li><a href="#dropdown">Dropdown</a></li>
           <li>
             <a href="#window">Window</a>
@@ -385,6 +386,44 @@
           <div class="field-row-stacked" style="width: 200px">
             <label for="text${getNewId()}">Additional notes</label>
             <textarea id="text${getCurrentId()}" rows="8"></textarea>
+          </div>
+        `) %>
+      </div>
+    </section>
+
+    <section class="component">
+      <h3 id="slider">Slider</h3>
+      <div>
+        <blockquote>
+          A <em>slider</em>, sometimes called a trackbar control, consists of a bar that
+          defines the extent or range of the adjustment and an indicator that
+          shows the current value for the control...
+
+          <footer>&mdash; Microsoft Windows User Experience p. 146</footer>
+        </blockquote>
+
+        <p>
+          Sliders can rendered by specifying a <code>range</code> type on an
+          <code>input</code> element.
+        </p>
+
+        <%- example(`
+          <div class="field-row">
+            <label for="range${getNewId()}">Cowbell</label>
+            <input id="range${getCurrentId()}" type="range" min="1" max="3" step="1" value="2" />
+          </div>
+        `) %>
+
+        <p>
+          You can make use of the <code>is-vertical</code> class to display the input
+          vertically, and use the <code>has-rectangular-indicator</code> class to use
+          a rectangular indicator.
+        </p>
+
+        <%- example(`
+          <div class="field-row">
+            <label for="range${getNewId()}">Volume</label>
+            <input id="range${getCurrentId()}" type="range" min="1" max="11" value="5" />
           </div>
         `) %>
       </div>

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -409,8 +409,10 @@
 
         <%- example(`
           <div class="field-row" style="width: 300px">
-            <label for="range${getNewId()}">Cowbell</label>
-            <input id="range${getCurrentId()}" type="range" min="1" max="3" step="1" value="2" />
+            <label for="range${getNewId()}">Volume:</label>
+            <label for="range${getNewId()}">Low</label>
+            <input id="range${getCurrentId()}" type="range" min="1" max="11" value="5" />
+            <label for="range${getNewId()}">High</label>
           </div>
         `) %>
 

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -417,17 +417,17 @@
         `) %>
 
         <p>
-          You can make use of the <code>is-vertical</code> class to display the input
-          vertically, and use the <code>has-rectangular-indicator</code> class to use
-          a rectangular indicator.
+          You can make use of the <code>has-box-indicator</code> class replace the
+          default indicator with a box indicator, furthermore the input can be wrapped
+          with a div using <code>is-vertical</code> to display the input vertically.
         </p>
 
         <%- example(`
-          <div class="field-row" style="width: 300px">
-            <label for="range${getNewId()}">Volume:</label>
-            <label for="range${getNewId()}">Low</label>
-            <input id="range${getCurrentId()}" class="has-rectangular-indicator" type="range" min="1" max="11" value="5" />
-            <label for="range${getNewId()}">High</label>
+          <div class="field-row" style="width: 150px">
+            <label for="range${getNewId()}">Cowbell</label>
+            <div class="is-vertical">
+              <input id="range${getCurrentId()}" class="has-box-indicator" type="range" min="1" max="3" step="1" value="2" />
+            </div>
           </div>
         `) %>
       </div>

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -408,7 +408,7 @@
         </p>
 
         <%- example(`
-          <div class="field-row">
+          <div class="field-row" style="width: 300px">
             <label for="range${getNewId()}">Cowbell</label>
             <input id="range${getCurrentId()}" type="range" min="1" max="3" step="1" value="2" />
           </div>
@@ -421,9 +421,11 @@
         </p>
 
         <%- example(`
-          <div class="field-row">
-            <label for="range${getNewId()}">Volume</label>
-            <input id="range${getCurrentId()}" type="range" min="1" max="11" value="5" />
+          <div class="field-row" style="width: 300px">
+            <label for="range${getNewId()}">Volume:</label>
+            <label for="range${getNewId()}">Low</label>
+            <input id="range${getCurrentId()}" class="has-rectangular-indicator" type="range" min="1" max="11" value="5" />
+            <label for="range${getNewId()}">High</label>
           </div>
         `) %>
       </div>

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -418,12 +418,17 @@
 
         <p>
           You can make use of the <code>has-box-indicator</code> class replace the
-          default indicator with a box indicator, furthermore the input can be wrapped
-          with a div using <code>is-vertical</code> to display the input vertically.
+          default indicator with a box indicator, furthermore the slider can be wrapped
+          with a <code>div</code> using <code>is-vertical</code> to display the input vertically.
+        </p>
+
+        <p>
+          Note: To change the length of a vertical slider, the <code>input</code> width
+          and <code>div</code> height.
         </p>
 
         <%- example(`
-          <div class="field-row" style="width: 150px">
+          <div class="field-row">
             <label for="range${getNewId()}">Cowbell</label>
             <div class="is-vertical">
               <input id="range${getCurrentId()}" class="has-box-indicator" type="range" min="1" max="3" step="1" value="2" />

--- a/icon/indicator-horizontal.svg
+++ b/icon/indicator-horizontal.svg
@@ -1,0 +1,6 @@
+<svg width="11" height="21" viewBox="0 0 11 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0V16H2V18H4V20H5V19H3V17H1V1H10V0Z" fill="white"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1 1V16H2V17H3V18H4V19H6V18H7V17H8V16H9V1Z" fill="#C0C7C8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9 1H10V16H8V18H6V20H5V19H7V17H9Z" fill="#87888F"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 0H11V16H9V18H7V20H5V21H6V19H8V17H10Z" fill="black"/>
+</svg>

--- a/icon/indicator-rectangle-horizontal.svg
+++ b/icon/indicator-rectangle-horizontal.svg
@@ -1,0 +1,6 @@
+<svg width="11" height="21" viewBox="0 0 11 21" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0V20H1V1H10V0Z" fill="white"/>
+<rect x="1" y="1" width="8" height="18" fill="#C0C7C8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M9 1H10V20H1V19H9Z" fill="#87888F"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M10 0H11V21H0V20H10Z" fill="black"/>
+</svg>

--- a/icon/indicator-rectangle-vertical.svg
+++ b/icon/indicator-rectangle-vertical.svg
@@ -1,0 +1,6 @@
+<svg width="21" height="11" viewBox="0 0 21 11" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0V11H1V1H20V0Z" fill="white"/>
+<rect x="1" y="1" width="18" height="8" fill="#C0C7C8"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M1 9V10H20V1H19V9Z" fill="#87888F"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 10V11H21V0H20V10Z" fill="black"/>
+</svg>

--- a/icon/indicator-rectangle-vertical.svg
+++ b/icon/indicator-rectangle-vertical.svg
@@ -1,6 +1,0 @@
-<svg width="21" height="11" viewBox="0 0 21 11" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0V11H1V1H20V0Z" fill="white"/>
-<rect x="1" y="1" width="18" height="8" fill="#C0C7C8"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M1 9V10H20V1H19V9Z" fill="#87888F"/>
-<path fill-rule="evenodd" clip-rule="evenodd" d="M0 10V11H21V0H20V10Z" fill="black"/>
-</svg>

--- a/style.css
+++ b/style.css
@@ -22,6 +22,8 @@
   --radio-width: 12px;
   --checkbox-width: 13px;
   --radio-label-spacing: 6px;
+  --range-track-height: 4px;
+  --range-spacing: 10px;
 
   /* Some detailed computations for radio buttons and checkboxes */
   --radio-total-width-precalc: var(--radio-width) + var(--radio-label-spacing);
@@ -506,13 +508,15 @@ input[type=range]::-moz-range-track {
   display: inline-block;
   width: 4px;
   height: 150px;
+  transform: translateY(50%) ;
 }
 
 .is-vertical > input[type=range] {
   width: 150px;
   height: 4px;
-  transform: rotate(270deg);
-  transform-origin: 75px 75px;
+  margin: 0 calc(var(--grouped-element-spacing) + var(--range-spacing)) 0 var(--range-spacing);
+  transform-origin: left;
+  transform: rotate(270deg) translateX(calc(-50% + var(--element-spacing))) ;
 }
 
 .is-vertical > input[type=range]::-webkit-slider-runnable-track {

--- a/style.css
+++ b/style.css
@@ -502,6 +502,65 @@ input[type=range]::-moz-range-track {
     1px -1px darkgrey;
 }
 
+.slider-vertical-wrapper {
+  display: inline-block;
+  width: 4px;
+  height: 150px;
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical {
+  width: 150px;
+  height: 4px;
+  transform: rotate(270deg);
+  transform-origin: 75px 75px;
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical::-webkit-slider-runnable-track {
+  border-left: 1px solid grey;
+  border-right: 0;
+  border-bottom: 1px solid grey;
+  box-shadow:
+    -1px 0 0 white,
+    -1px 1px 0 white,
+    0 1px 0 white,
+    1px 0 0 darkgrey,
+    1px -1px 0 darkgrey,
+    0 -1px 0 darkgrey,
+    1px 1px 0 white,
+    -1px -1px darkgrey;
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical::-moz-range-track {
+  border-left: 1px solid grey;
+  border-right: 0;
+  border-bottom: 1px solid grey;
+  box-shadow:
+    -1px 0 0 white,
+    -1px 1px 0 white,
+    0 1px 0 white,
+    1px 0 0 darkgrey,
+    1px -1px 0 darkgrey,
+    0 -1px 0 darkgrey,
+    1px 1px 0 white,
+    -1px -1px darkgrey;
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical::-webkit-slider-thumb {
+  transform: translateY(-8px) scaleX(-1);
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical.has-rectangular-indicator::-webkit-slider-thumb {
+  transform: translateY(-10px) scaleX(-1);
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical::-moz-range-thumb {
+  transform: translateY(2x) scaleX(-1);
+}
+
+.slider-vertical-wrapper > input[type=range].is-vertical.has-rectangular-indicator::-moz-range-thumb {
+  transform: translateY(0px) scaleX(-1);
+}
+
 select:focus {
   color: var(--button-highlight);
   background-color: var(--dialog-blue);

--- a/style.css
+++ b/style.css
@@ -429,6 +429,28 @@ textarea:focus {
   outline: none;
 }
 
+input[type=range] {
+  -webkit-appearance: none;
+  width: 100%;
+  background: transparent;
+}
+
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+}
+
+input[type=range]:focus {
+  outline: none;
+}
+
+input[type=range]::-ms-track {
+  width: 100%;
+  cursor: pointer;
+  background: transparent; 
+  border-color: transparent;
+  color: transparent;
+}
+
 select:focus {
   color: var(--button-highlight);
   background-color: var(--dialog-blue);

--- a/style.css
+++ b/style.css
@@ -451,6 +451,11 @@ input[type=range]::-webkit-slider-thumb {
   transform: translateY(-8px);
 }
 
+input[type=range].has-rectangular-indicator::-webkit-slider-thumb {
+  background: svg-load("./icon/indicator-rectangle-horizontal.svg");
+  transform: translateY(-10px);
+}
+
 input[type=range]::-moz-range-thumb {
   height: 21px;
   width: 11px;
@@ -458,6 +463,11 @@ input[type=range]::-moz-range-thumb {
   border-radius: 0;
   background: svg-load("./icon/indicator-horizontal.svg");
   transform: translateY(2px);
+}
+
+input[type=range].has-rectangular-indicator::-moz-range-thumb {
+  background: svg-load("./icon/indicator-rectangle-horizontal.svg");
+  transform: translateY(0px);
 }
 
 input[type=range]::-webkit-slider-runnable-track {

--- a/style.css
+++ b/style.css
@@ -451,6 +451,31 @@ input[type=range]::-ms-track {
   color: transparent;
 }
 
+input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  height: 21px;
+  width: 11px;
+  background: svg-load("./icon/indicator-horizontal.svg");
+}
+
+input[type=range]::-moz-range-thumb {
+  height: 21px;
+  width: 11px;
+  border: 0;
+  border-radius: 0;
+  background: svg-load("./icon/indicator-horizontal.svg");
+}
+
+input[type=range]::-ms-thumb {
+  height: 21px;
+  width: 11px;
+  border: 0;
+  background: svg-load("./icon/indicator-horizontal.svg");
+}
+input[type=range]::-ms-track {
+  height: 21px;
+}
+
 select:focus {
   color: var(--button-highlight);
   background-color: var(--dialog-blue);

--- a/style.css
+++ b/style.css
@@ -443,19 +443,12 @@ input[type=range]:focus {
   outline: none;
 }
 
-input[type=range]::-ms-track {
-  width: 100%;
-  cursor: pointer;
-  background: transparent; 
-  border-color: transparent;
-  color: transparent;
-}
-
 input[type=range]::-webkit-slider-thumb {
   -webkit-appearance: none;
   height: 21px;
   width: 11px;
   background: svg-load("./icon/indicator-horizontal.svg");
+  transform: translateY(-8px);
 }
 
 input[type=range]::-moz-range-thumb {
@@ -464,16 +457,43 @@ input[type=range]::-moz-range-thumb {
   border: 0;
   border-radius: 0;
   background: svg-load("./icon/indicator-horizontal.svg");
+  transform: translateY(2px);
 }
 
-input[type=range]::-ms-thumb {
-  height: 21px;
-  width: 11px;
-  border: 0;
-  background: svg-load("./icon/indicator-horizontal.svg");
+input[type=range]::-webkit-slider-runnable-track {
+  width: 100%;
+  height: 2px;
+  box-sizing: border-box;
+  background: black;
+  border-right: 1px solid grey;
+  border-bottom: 1px solid grey;
+  box-shadow:
+    1px 0 0 white,
+    1px 1px 0 white,
+    0 1px 0 white,
+    -1px 0 0 darkgrey,
+    -1px -1px 0 darkgrey,
+    0 -1px 0 darkgrey,
+    -1px 1px 0 white,
+    1px -1px darkgrey;
 }
-input[type=range]::-ms-track {
-  height: 21px;
+
+input[type=range]::-moz-range-track {
+  width: 100%;
+  height: 2px;
+  box-sizing: border-box;
+  background: black;
+  border-right: 1px solid grey;
+  border-bottom: 1px solid grey;
+  box-shadow:
+    1px 0 0 white,
+    1px 1px 0 white,
+    0 1px 0 white,
+    -1px 0 0 darkgrey,
+    -1px -1px 0 darkgrey,
+    0 -1px 0 darkgrey,
+    -1px 1px 0 white,
+    1px -1px darkgrey;
 }
 
 select:focus {

--- a/style.css
+++ b/style.css
@@ -558,7 +558,7 @@ input[type=range]::-moz-range-track {
 }
 
 .is-vertical > input[type=range]::-moz-range-thumb {
-  transform: translateY(2x) scaleX(-1);
+  transform: translateY(2px) scaleX(-1);
 }
 
 .is-vertical > input[type=range].has-box-indicator::-moz-range-thumb {

--- a/style.css
+++ b/style.css
@@ -435,10 +435,6 @@ input[type=range] {
   background: transparent;
 }
 
-input[type=range]::-webkit-slider-thumb {
-  -webkit-appearance: none;
-}
-
 input[type=range]:focus {
   outline: none;
 }

--- a/style.css
+++ b/style.css
@@ -447,7 +447,7 @@ input[type=range]::-webkit-slider-thumb {
   transform: translateY(-8px);
 }
 
-input[type=range].has-rectangular-indicator::-webkit-slider-thumb {
+input[type=range].has-box-indicator::-webkit-slider-thumb {
   background: svg-load("./icon/indicator-rectangle-horizontal.svg");
   transform: translateY(-10px);
 }
@@ -461,7 +461,7 @@ input[type=range]::-moz-range-thumb {
   transform: translateY(2px);
 }
 
-input[type=range].has-rectangular-indicator::-moz-range-thumb {
+input[type=range].has-box-indicator::-moz-range-thumb {
   background: svg-load("./icon/indicator-rectangle-horizontal.svg");
   transform: translateY(0px);
 }
@@ -502,20 +502,20 @@ input[type=range]::-moz-range-track {
     1px -1px darkgrey;
 }
 
-.slider-vertical-wrapper {
+.is-vertical {
   display: inline-block;
   width: 4px;
   height: 150px;
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical {
+.is-vertical > input[type=range] {
   width: 150px;
   height: 4px;
   transform: rotate(270deg);
   transform-origin: 75px 75px;
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical::-webkit-slider-runnable-track {
+.is-vertical > input[type=range]::-webkit-slider-runnable-track {
   border-left: 1px solid grey;
   border-right: 0;
   border-bottom: 1px solid grey;
@@ -530,7 +530,7 @@ input[type=range]::-moz-range-track {
     -1px -1px darkgrey;
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical::-moz-range-track {
+.is-vertical > input[type=range]::-moz-range-track {
   border-left: 1px solid grey;
   border-right: 0;
   border-bottom: 1px solid grey;
@@ -545,19 +545,19 @@ input[type=range]::-moz-range-track {
     -1px -1px darkgrey;
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical::-webkit-slider-thumb {
+.is-vertical > input[type=range]::-webkit-slider-thumb {
   transform: translateY(-8px) scaleX(-1);
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical.has-rectangular-indicator::-webkit-slider-thumb {
+.is-vertical > input[type=range].has-box-indicator::-webkit-slider-thumb {
   transform: translateY(-10px) scaleX(-1);
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical::-moz-range-thumb {
+.is-vertical > input[type=range]::-moz-range-thumb {
   transform: translateY(2x) scaleX(-1);
 }
 
-.slider-vertical-wrapper > input[type=range].is-vertical.has-rectangular-indicator::-moz-range-thumb {
+.is-vertical > input[type=range].has-box-indicator::-moz-range-thumb {
   transform: translateY(0px) scaleX(-1);
 }
 


### PR DESCRIPTION
Add styling to input[type="range"] to resemble windows 98 sliders (is missing ticks). Input can be further styled with `has-box-indicator` to replace default indicator with rectangular inidcator, and made vertical by wrapping it in a div with class `is-vertical`. Docs are updated to include slider component.

Docs in chrome:
![range-chrome](https://user-images.githubusercontent.com/16689477/80841989-70de7980-8bf8-11ea-8103-25788bdc1509.png)

Docs in Firefox with indicators swapped:
![range-firefox](https://user-images.githubusercontent.com/16689477/80841994-72a83d00-8bf8-11ea-8060-c84bf8c07eaa.png)

Tested in latest Chrome, Firefox, Edge (does not work in IE)