### PR TITLE
Move button text when pressing

### DIFF
--- a/style.css
+++ b/style.css
@@ -144,6 +144,10 @@ button {
 
 button:not(:disabled):active {
   box-shadow: var(--border-sunken-outer), var(--border-sunken-inner);
+  border-top: 1px solid transparent;
+  border-right: 0px solid transparent;
+  border-bottom: 0px solid transparent;
+  border-left: 1px solid transparent;
 }
 
 @media (not(hover)) {


### PR DESCRIPTION
Fixes  #34 .

I went with an invisible `border` instead of changing the button's `padding`, as per @tpenguinltg 's suggestion on #44.

Looks like it works fine in the most recent versions of Chrome, Firefox and Safari on Mac. 
Here's how it looks (might be hard to see the difference, though):
<img width="861" alt="Screenshot 2020-05-03 at 23 16 58" src="https://user-images.githubusercontent.com/16888880/80926193-f186ac80-8d95-11ea-86b3-344fabb26b10.png">
(I think there's an unrelated bug on Safari which changes the button text `color` to `white`, and the dotted `outline` only shows up on Chrome)

Also, this is my very first PR, ever :)