### PR TITLE
Align "+"/"-" in ul.tree-view details

### DIFF
--- a/style.css
+++ b/style.css
@@ -667,7 +667,7 @@ ul.tree-view details > summary:before {
   border: 1px solid #808080;
   width: 8px;
   height: 9px;
-  line-height: 9px;
+  line-height: 8px;
   margin-right: 5px;
   padding-left: 1px;
   background-color: #fff;


### PR DESCRIPTION
In Firefox 76.0.1 on windows 10, the '+'/'-' signs in the expandable tree view look slightly misaligned:
![before](https://user-images.githubusercontent.com/25933468/82150800-67404d00-9859-11ea-8f05-99bd94ddc846.png)
This commit aligns them better:
![after](https://user-images.githubusercontent.com/25933468/82150808-70c9b500-9859-11ea-8682-fd0dc29727f7.png)
If this breaks it on any other platform, sorry, don't have the means to test it atm. Then please view this as an issue report.