### PR TITLE
Adding tabs

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -534,7 +534,7 @@
           assistive technologies know the intent of this button. You may also use
           "Minimize", "Maximize", "Restore" and "Help" like so:
         </p>
-        
+
         <%- example(`
           <div class="title-bar">
             <div class="title-bar-text">A Title Bar</div>
@@ -564,7 +564,7 @@
               <button aria-label="Help"></button>
               <button aria-label="Close"></button>
             </div>
-          </div>          
+          </div>
         `) %>
 		<p>
           You can make a title bar "inactive" by adding <code>inactive</code> class,
@@ -716,6 +716,83 @@
             <li>HTML</li>
             <li>Special Thanks</li>
           </ul>
+        `) %>
+      </div>
+    </section>
+
+    <section class="component">
+      <h3 id="tabs">Tabs</h3>
+      <div>
+        <blockquote>
+          ...
+
+          <footer>
+            &mdash; Microsoft Windows User Experience p. #
+          </footer>
+        </blockquote>
+
+        <p>
+          To render a tab list, use a <code>menu</code> element with the
+          <code>[role=tablist]</code> attribute. The children of this menu (<code>li</code>
+          elements), should get a <code>[role=tab]</code> attribute.
+        </p>
+
+        <p>
+          Tabs should be managed by adding custom javascript code.
+          All you need is to add the <code>[aria-selected=true]</code> attribute to the active tab.
+        </p>
+
+        <%- example(`
+        <div class="window-body">
+          <p>Hello, world!</p>
+
+          <menu role="tablist">
+            <li role="tab" aria-selected="true"><a href="#">Desktop</a></li>
+            <li role="tab"><a href="#">My computer</a></li>
+            <li role="tab"><a href="#">Control panel</a></li>
+            <li role="tab"><a href="#">Devices manager</a></li>
+            <li role="tab"><a href="#">Hardware profiles</a></li>
+            <li role="tab"><a href="#">Performance</a></li>
+          </menu>
+          <div class="window" role="tabpanel">
+            <div class="window-body">
+              <p>the tab content</p>
+            </div>
+          </div>
+        </div>
+        `) %>
+
+        <p>
+          To create multirows tabs, add a <code>multirows</code>
+          class to the <code>menu</code> tag.
+        </p>
+
+        <%- example(`
+        <div class="window-body">
+          <p>Hello, world!</p>
+
+          <menu role="tablist" class="multirows">
+            <li role="tab"><a href="#">Desktop</a></li>
+            <li role="tab"><a href="#">My computer</a></li>
+            <li role="tab"><a href="#">Control panel</a></li>
+            <li role="tab"><a href="#">Devices manager</a></li>
+            <li role="tab"><a href="#">Hardware profiles</a></li>
+            <li role="tab"><a href="#">Performance</a></li>
+          </menu>
+          <menu role="tablist" class="multirows">
+            <li role="tab"><a href="#">Users</a></li>
+            <li role="tab"><a href="#">Network</a></li>
+            <li role="tab"><a href="#">Programs</a></li>
+            <li role="tab"><a href="#">Services</a></li>
+            <li role="tab"><a href="#">Resources</a></li>
+            <li role="tab"><a href="#">Advanced</a></li>
+          </menu>
+          <div class="window" role="tabpanel">
+            <div class="window-body">
+              <p>the tab content</p>
+            </div>
+          </div>
+        </div>
         `) %>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -738,7 +738,12 @@ summary:focus {
   background-image: svg-load("./icon/button-right.svg");
 }
 
-menu.tabs {
+.window[role=tabpanel] {
+  position: relative;
+  z-index: 2;
+}
+
+menu[role=tablist] {
   position: relative;
   margin: 0 0 -2px 0;
   text-indent: 0;
@@ -747,13 +752,14 @@ menu.tabs {
   padding-left: 3px;
 }
 
-menu.tabs li {
+menu[role=tablist] > li {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   box-shadow: var(--border-tab);
   z-index: 1;
 }
-menu.tabs > li.active {
+
+menu[role=tablist] > li[aria-selected] {
   padding-bottom: 2px;
   margin-top: -2px;
   background-color: var(--surface);
@@ -762,20 +768,20 @@ menu.tabs > li.active {
   margin-left: -3px;
 }
 
-menu.tabs > li > a {
+menu[role=tablist] > li > a {
   display: block;
   color: #222;
   margin: 6px;
   text-decoration: none;
 }
-menu.tabs > li.active > a:focus {
+menu[role=tablist] > li[aria-selected] > a:focus {
   outline: none;
 }
-menu.tabs > li > a:focus {
+menu[role=tablist] > li > a:focus {
   outline: 1px dotted #222;
 }
 
-menu.tabs.justified > li {
+menu[role=tablist].justified > li {
   flex-grow: 1;
   text-align: center;
 }

--- a/style.css
+++ b/style.css
@@ -68,6 +68,11 @@
   --border-field: inset -1px -1px var(--button-highlight),
     inset 1px 1px var(--button-shadow), inset -2px -2px var(--button-face),
     inset 2px 2px var(--window-frame);
+
+  --border-tab: inset -1px 0 var(--window-frame),
+    inset 1px 1px var(--button-highlight),
+    inset -2px 0 var(--button-shadow),
+    inset 2px 2px var(--button-face)
 }
 
 @font-face {
@@ -731,4 +736,46 @@ summary:focus {
 ::-webkit-scrollbar-button:horizontal:end {
   width: 16px;
   background-image: svg-load("./icon/button-right.svg");
+}
+
+menu.tabs {
+  position: relative;
+  margin: 0 0 -2px 0;
+  text-indent: 0;
+  list-style-type: none;
+  display: flex;
+  padding-left: 3px;
+}
+
+menu.tabs li {
+  border-top-left-radius: 3px;
+  border-top-right-radius: 3px;
+  box-shadow: var(--border-tab);
+  z-index: 1;
+}
+menu.tabs > li.active {
+  padding-bottom: 2px;
+  margin-top: -2px;
+  background-color: var(--surface);
+  position: relative;
+  z-index: 8;
+  margin-left: -3px;
+}
+
+menu.tabs > li > a {
+  display: block;
+  color: #222;
+  margin: 6px;
+  text-decoration: none;
+}
+menu.tabs > li.active > a:focus {
+  outline: none;
+}
+menu.tabs > li > a:focus {
+  outline: 1px dotted #222;
+}
+
+menu.tabs.justified > li {
+  flex-grow: 1;
+  text-align: center;
 }

--- a/style.css
+++ b/style.css
@@ -69,10 +69,11 @@
     inset 1px 1px var(--button-shadow), inset -2px -2px var(--button-face),
     inset 2px 2px var(--window-frame);
 
+  /* Tabs */
   --border-tab: inset -1px 0 var(--window-frame),
-    inset 1px 1px var(--button-highlight),
+    inset 1px 1px var(--button-face),
     inset -2px 0 var(--button-shadow),
-    inset 2px 2px var(--button-face)
+    inset 2px 2px var(--button-highlight)
 }
 
 @font-face {

--- a/style.css
+++ b/style.css
@@ -782,7 +782,7 @@ menu[role=tablist] > li > a:focus {
   outline: 1px dotted #222;
 }
 
-menu[role=tablist].justified > li {
+menu[role=tablist].multirows > li {
   flex-grow: 1;
   text-align: center;
 }

--- a/style.css
+++ b/style.css
@@ -760,7 +760,7 @@ menu[role=tablist] > li {
   z-index: 1;
 }
 
-menu[role=tablist] > li[aria-selected] {
+menu[role=tablist] > li[aria-selected=true] {
   padding-bottom: 2px;
   margin-top: -2px;
   background-color: var(--surface);
@@ -775,7 +775,7 @@ menu[role=tablist] > li > a {
   margin: 6px;
   text-decoration: none;
 }
-menu[role=tablist] > li[aria-selected] > a:focus {
+menu[role=tablist] > li[aria-selected=true] > a:focus {
   outline: none;
 }
 menu[role=tablist] > li > a:focus {


### PR DESCRIPTION
This is a re-opening of closed pull-request - #32 - reproducing W98 tabs - #21.

I looked at how tabs behaves in W98 and it looks like normal tabs are justified left.
Then only when tabs become multi-rows then they are justified in full width. 
Also i think i remember the row where belongs the active tabs is always pulled down, isn't it ?

Here are some single row tabs:
![tabs](https://user-images.githubusercontent.com/24324122/97057803-5a542200-158c-11eb-8407-d660aecc283a.gif)

And some multi-rows tabs:
![multirows](https://user-images.githubusercontent.com/24324122/97060993-9344c480-1595-11eb-8e83-cb78edf1a203.gif)

Here is the HTML
```HTML
<menu class="tabs">
  <li class="active"><a href="#">Desktop</a></li>
  <li><a href="#">My computer</a></li>
  <li><a href="#">Control panel</a></li>
  <li><a href="#">Devices manager</a></li>
  <li><a href="#">Hardware profiles</a></li>
  <li><a href="#">Performance</a></li>
</menu>
<div class="window">
  <div class="window-body">
    <!-- the tab content -->
  </div>
</div>
```

For multi-row you can use `.multirows`.
There is a huge room for improvement on the multi-rows html semantic. Currently each row requires its own `menu`.

Coming next time :
> W98 will always pull down the rows that has the active tab as seen in the demo gif.
> I would like to convert `menu > li` to `nav > ul > li` in the futur, which would allow having multiple `ul`s instead.
> The active `ul` tab row would simply get pulled-down with an `.active` class using flex ordering. 
> We cannot reproduce this behavior with css only until CSS4 is available and supported.

Given i tried to reuse the `.window` as a tab container i had to find some hacks and made use of z-index in order to pull the active tab upfront and cover the container borders.

Best 🙂 