### PR TITLE
Fix GroupBox border for Firefox

### DIFF
--- a/icon/groupbox-border.svg
+++ b/icon/groupbox-border.svg
@@ -1,0 +1,4 @@
+<svg width="5" height="5" viewBox="0 0 5 5" fill="grey" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H5V5H0V2H2V3H3V2H0" fill="white" />
+<path fill-rule="evenodd" clip-rule="evenodd" d="M0 0H4V4H0V1H1V3H3V1H0" fill="#808080" />
+</svg>

--- a/style.css
+++ b/style.css
@@ -278,9 +278,7 @@ button:disabled,
 }
 
 fieldset {
-  border: none;
-  box-shadow: inset -1px -1px var(--button-highlight), inset -2px 1px var(--button-shadow),
-    inset 1px -2px var(--button-shadow), inset 2px 2px var(--button-highlight);
+  border-image: svg-load("./icon/groupbox-border.svg") 2;
   padding: calc(2 * var(--border-width) + var(--element-spacing));
   padding-block-start: var(--element-spacing);
   margin: 0;


### PR DESCRIPTION
Firefox's new WebRender engine seems to have a bug with fieldsets styled with inset box-shadows (https://bugzilla.mozilla.org/show_bug.cgi?id=1496538).

As a workaround, use a tiny .SVG as a sliced border-image to draw the border.

Fixes #42.

Tested on Firefox 90.0.2 and Chromium 92.0.4515.131.

![2021-08-06-143958_1911x2118_scrot](https://user-images.githubusercontent.com/5890747/128519840-e5cf5794-e2a6-4d00-b267-6c2bdbf4433c.png)
