### PR TITLE
Remove user agent summary arrow

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -102,10 +102,6 @@ summary {
   display: inline;
 }
 
-summary::-webkit-details-marker {
-    display: none;
-}
-
 details[open] summary {
   margin-bottom: 8px;
 }

--- a/style.css
+++ b/style.css
@@ -696,7 +696,7 @@ ul.tree-view details[open] > summary:before {
 }
 
 ul.tree-view details > summary::marker, ul.tree-view details > summary::-webkit-details-marker {
-  display: none;
+  content: "";
 }
 
 pre {

--- a/style.css
+++ b/style.css
@@ -266,7 +266,7 @@ button:disabled,
 }
 
 .status-bar-field {
-  box-shadow: inset -1px -1px  #dfdfdf, 
+  box-shadow: inset -1px -1px  #dfdfdf,
     inset 1px 1px #808080;
   flex-grow: 1;
   padding: 2px 3px;
@@ -693,6 +693,10 @@ ul.tree-view details > summary:before {
 
 ul.tree-view details[open] > summary:before {
   content: "-";
+}
+
+ul.tree-view details > summary::marker, ul.tree-view details > summary::-webkit-details-marker {
+  display: none;
 }
 
 pre {


### PR DESCRIPTION
Browsers by default show an arrow next to `<summary>` elements, this is redundant for 98.css as it has it's own marker. Without disabling this marker two separate markers will be shown: 

![image](https://user-images.githubusercontent.com/885544/169406665-2eb57eb3-3a01-4706-8d46-af1d784823ea.png)

docs.css fixed this for the docs website but this is  something that should be pulled up to the main stylesheet. 

The rule uses the new [::marker pseduo-element](https://developer.mozilla.org/en-US/docs/Web/CSS/::marker) which is supported by all modern browsers except for Safari which is why the vendor prefixed ::-webkit-details-marker is also included. 

(Beta versions of Safari add support for ::marker so the vendor prefixed selector could be dropped in the near future)
