### PR TITLE
Fix issue where active button style pushes content down 1px

### DIFF
--- a/style.css
+++ b/style.css
@@ -138,7 +138,8 @@ input[type="reset"] {
 
   min-width: 75px;
   min-height: 23px;
-  padding: 0 12px;
+  --original-padding-x: 12px;
+  padding: 0 var(--original-padding-x);
 }
 
 .vertical-bar {
@@ -153,11 +154,11 @@ input[type="submit"]:not(:disabled):active,
 input[type="reset"]:not(:disabled):active {
   box-shadow: var(--border-sunken-outer), var(--border-sunken-inner);
 
-  /* Make the text to appear to shift down and right 1px without affecting any
-  surrounding layout */
+  /* Shift text down and right 1px without affecting any surrounding layout */
   vertical-align: -1px;
   margin-bottom: -1px;
-  padding: 1px 0 0 2px;
+  padding: 1px calc(var(--original-padding-x) - 1px) 0
+    calc(var(--original-padding-x) + 1px);
   position: relative;
   top: -0.5px;
 }

--- a/style.css
+++ b/style.css
@@ -152,7 +152,14 @@ button:not(:disabled):active,
 input[type="submit"]:not(:disabled):active,
 input[type="reset"]:not(:disabled):active {
   box-shadow: var(--border-sunken-outer), var(--border-sunken-inner);
-  padding: 2px 11px 0 13px;
+
+  /* Make the text to appear to shift down and right 1px without affecting any
+  surrounding layout */
+  vertical-align: -1px;
+  margin-bottom: -1px;
+  padding: 1px 0 0 2px;
+  position: relative;
+  top: -0.5px;
 }
 
 @media (not(hover)) {


### PR DESCRIPTION
Previously, when a button was pressed, the content below it would shift down 1px. This bug was introduced in #44 which added the effect of the text shifting left and down 1px on press.

After this commit, the text of the button still correctly shifts down and left 1px but the overall height of the button does not change.

This commit introduces a small issue where the button does not shift down visually in Safari.

Fix #145