### PR TITLE
Fix slider thumb inconsistency on iOS

### DIFF
--- a/style.css
+++ b/style.css
@@ -517,6 +517,8 @@ input[type="range"]::-webkit-slider-thumb {
   width: 11px;
   background: svg-load("./icon/indicator-horizontal.svg");
   transform: translateY(-8px);
+  box-shadow: none;
+  border: none;
 }
 
 input[type="range"].has-box-indicator::-webkit-slider-thumb {


### PR DESCRIPTION
Fixes the slider thumb on iOS.

The slider thumb on iOS 16 had a drop shadow and on iOS 14 it had a border. This PR removes both issues.

<img width="854" alt="Screenshot 2022-10-24 at 09 04 40" src="https://user-images.githubusercontent.com/72999/197468043-7840b879-1ee4-4ab5-bccf-2a2c6dd5e67f.png">
