### PR TITLE
ench: set font size and margins for tab item

### DIFF
--- a/style.css
+++ b/style.css
@@ -107,6 +107,7 @@ select,
 option,
 table,
 ul.tree-view,
+menu[role=tablist],
 .window,
 .title-bar {
   font-family: "Pixelated MS Sans Serif", Arial;
@@ -837,7 +838,7 @@ menu[role=tablist] > li[aria-selected=true] {
 menu[role=tablist] > li > a {
   display: block;
   color: #222;
-  margin: 6px;
+  margin: 5px 8px;
   text-decoration: none;
 }
 menu[role=tablist] > li[aria-selected=true] > a:focus {


### PR DESCRIPTION
### Description
This pr makes tab margin and font size similar to Windows 98 GUI

### Screenshots
| Before | After |
| ------- | ------ |
| ![image](https://user-images.githubusercontent.com/44939683/233770041-4784186a-4bb4-4011-b249-f79f05f4c42b.png) | ![image](https://user-images.githubusercontent.com/44939683/233770043-ed426820-648e-4fb6-bbbf-199c635ebfa4.png) |

