### PR TITLE
Progress indicator (a.k.a. progress bar control)

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -43,6 +43,7 @@
           <li><a href="#tree-view">TreeView</a></li>
           <li><a href="#tabs">Tabs</a></li>
           <li><a href="#table-view">TableView</a></li>
+          <li><a href="#progress-indicator">Progress Indicator</a></li>
         </ul>
       </li>
       <li><a href="#issues-contributing-etc">Issues, Contributing, etc.</a></li>
@@ -878,7 +879,6 @@
               </div>
     </section>
     <section class="component">
-
       <h3 id="table-view">TableView</h3>
       <div>
         <p>
@@ -965,6 +965,35 @@
             });
           </script>
       `) %>
+    </div>
+    </section>
+
+    <section class="component">
+      <h3 id="progress-indicator">Progress Indicator</h3>
+      <div>
+        <blockquote>
+          A <em>ProgressIndicator</em> is a control, also known as a <em>progress bar control</em>, you can use to show the percentage of completion of a lengthy operation.
+
+          <footer>
+            &mdash; Microsoft Windows User Experience p. 142
+          </footer>
+        </blockquote>
+
+        <p>
+          The ProgressIndicator component supports two types of bars. Both are deterministic, which means that you should give it a <code>value</code> parameter. Indeterministic progress bars are not supported, yet.
+        </p>
+
+        <p>
+          There are two types of progress bars: continuous and block. The continuous doesn't require any further configuration. The block bar does require a class of <code>progress-bar-block</code>.
+        </p>
+
+        <%- example(`
+          <progress value="50" max="100"></progress>
+        `) %>
+
+        <%- example(`
+          <progress class="progress-bar-block" value="70" max="100"></progress>
+        `) %>
       </div>
     </section>
 

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -972,27 +972,27 @@
       <h3 id="progress-indicator">Progress Indicator</h3>
       <div>
         <blockquote>
-          A <em>ProgressIndicator</em> is a control, also known as a <em>progress bar control</em>, you can use to show the percentage of completion of a lengthy operation.
+          You can use a <em>progress indicator</em>, also known as a <em>progress bar control</em>, to show the percentage of completion of a lengthy operation.
 
           <footer>
-            &mdash; Microsoft Windows User Experience p. 142
+            &mdash; Microsoft Windows User Experience p. 189
           </footer>
         </blockquote>
 
         <p>
-          The ProgressIndicator component supports two types of bars. Both are deterministic, which means that you should give it a <code>value</code> parameter. Indeterministic progress bars are not supported, yet.
-        </p>
-
-        <p>
-          There are two types of progress bars: continuous and block. The continuous doesn't require any further configuration. The block bar does require a class of <code>progress-bar-block</code>.
+          There are two types of progress bars: solid and segmented. The solid version is the default. To declare a segmented bar, you should use the <code>segmented</code> class.
         </p>
 
         <%- example(`
-          <progress value="50" max="100"></progress>
+          <div class="progress-indicator">
+            <span class="progress-indicator-bar"  style="width: 40%;" />
+          </div>
         `) %>
 
         <%- example(`
-          <progress class="progress-bar-block" value="70" max="100"></progress>
+          <div class="progress-indicator segmented">
+            <span class="progress-indicator-bar" style="width: 40%;" />
+          </div>
         `) %>
       </div>
     </section>

--- a/style.css
+++ b/style.css
@@ -885,3 +885,35 @@ table > tbody > tr > * {
   padding: 0 var(--grouped-element-spacing);
   height: 14px;
 }
+
+.progress-indicator {
+	height: 32px;
+	position: relative;
+  box-shadow: var(--border-sunken-inner);
+  padding: 4px 4px;
+  border: none;
+  box-sizing: border-box;
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  border-radius: 0;
+}
+
+
+.progress-indicator > .progress-indicator-bar {
+  height: 100%;
+  display: block;
+  background-color: var(--dialog-blue);
+}
+
+.progress-indicator.segmented > .progress-indicator-bar {
+  width: 100%;
+  background-color: transparent; /* resets the background color which is set to blue in the non-segmented selector */
+  background-image: linear-gradient(
+    90deg,
+    var(--dialog-blue) 0 16px,
+    transparent 0 2px
+  );
+  background-repeat: repeat;
+  background-size: 18px 100%;
+}


### PR DESCRIPTION
Closes #18 

I'm salvaging [this PR from 2020](https://github.com/jdan/98.css/pull/70) and [this PR](https://github.com/jdan/98.css/pull/96), as both were closed after the migration from `master `to `main`.

I ended up simplifying the implementation and solving a few issues such as the borders not being those seen on Windows 98 screenshots.

One thing that neither of those PRs have is a way to make the blue blocks discrete (there should never be half a block in the middle of a progress indicator). However, as long as the CSS round() function isn't implemented, I do not believe that there is a way to solve this and keep respecting the aspect ratio of the blocks in the segmented version of the progress bar.

Sadly I was unable to save the HTML `<progress>` implementation, which would've been more semantically correct.

I looked up screenshots and the blocks in the  are sometimes 8x12 px with 2px separation OR 6x9 px with 2px separation. I have implemented only the 8x12 version at this time.