### PR TITLE
fix exception on table element click

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -961,9 +961,16 @@
           <script>
             document.querySelectorAll('table.interactive').forEach(element => {
               element.addEventListener('click', (event) => {
-                const row = event.path.find(element => element.tagName === 'TR' && element.parentElement.tagName === 'TBODY');
-                if (row) {
-                  row.classList.toggle('highlighted');
+                const highlightedClass = 'highlighted';
+                const isRow = element => element.tagName === 'TR' && element.parentElement.tagName === 'TBODY';
+                const newlySelectedRow = event.composedPath().find(isRow);
+                const previouslySelectedRow = Array.from(newlySelectedRow.parentElement.children).filter(isRow).find(element => element.classList.contains(highlightedClass));
+                if(previouslySelectedRow){
+                  previouslySelectedRow.classList.toggle(highlightedClass);
+                }
+
+                if (newlySelectedRow) {
+                  newlySelectedRow.classList.toggle(highlightedClass);
                 }
               })
             });


### PR DESCRIPTION
Fixes #172

I fixed the exception that was thrown and touched up the implementation a bit so that only one row, if any, can be highlighted at any given time.