### PR TITLE
make tab font pixelated

### DIFF
--- a/style.css
+++ b/style.css
@@ -108,7 +108,8 @@ option,
 table,
 ul.tree-view,
 .window,
-.title-bar {
+.title-bar,
+li[role=tab] {
   font-family: "Pixelated MS Sans Serif", Arial;
   -webkit-font-smoothing: none;
   font-size: 11px;


### PR DESCRIPTION
Fixes #174 

Before:

![image](https://github.com/jdan/98.css/assets/31663056/8bd7613f-4992-41d5-93d7-4569f54f3013)


After:

![image](https://github.com/jdan/98.css/assets/31663056/5e9d787d-3137-48eb-bb6e-b1132678f2e3)
