### PR TITLE
Font styling applied to `<legend>`

### DIFF
--- a/style.css
+++ b/style.css
@@ -102,6 +102,7 @@ body {
 button,
 label,
 input,
+legend,
 textarea,
 select,
 option,


### PR DESCRIPTION
## In this PR:

Added `<legend>` to the grouped font-styling selector. 

## 💭 Reasoning

When used as a child of a `.window` element, `<legend>` gets the appropriate font styling applied to it to resemble Windows 98 font styling for _group boxes_.[^1]

However, when `<legend>` is not a child of a `.window` element, it will have `font-family: Arial` applied to it, inherited from `<body>`. This issue is most prominent in the documentation, where it appears that `<legend>` is exempt from the universal font styling of `.window` elements.

<img width="967" alt="Screenshot 2024-01-20 at 9 06 07 PM" src="https://github.com/jdan/98.css/assets/15847889/7c96b4e0-815f-49cd-9cc4-7f29bd96a225">

With this proposed fix, `<legend>` will have the appropriate font styling regardless of being a child of a `.window` element.

<img width="903" alt="Screenshot 2024-01-20 at 9 08 13 PM" src="https://github.com/jdan/98.css/assets/15847889/c420652d-1973-4260-b0be-6ade1233cc47">

## 📈 Impact

This change should make it clear to first-time readers of the documentation what the intended styling for `<legend>` is, instead of relying users of 98.css to try out the example code or use `<legend>` in their code. 

## 📔 Dev Note

Seems like a similar issue is happening with the `.field-row` class when used with text content in `<fieldset>`. However, I'm not certain about applying font-styling to an element that doesn't necessarily have to do with any text, or if the real issue was the documentation itself using a `<div>` for that text content over `<p>` or another element. Because of this, I chose not to fix that in this PR. I figured scoping down to just focus on `<legend>` would be enough for a PR to this neat open-source project!

[^1]: drawing from examples from this link: https://guidebookgallery.org/screenshots/win98