### PR TITLE
Add `class` alts for `aria-labels`

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -94,7 +94,7 @@
     <p>
       This library relies on the usage of <strong>semantic HTML</strong>. To make a button, you'll need
       to use a <code>&lt;button&gt;</code>. Input elements require labels. Icon buttons rely on
-      <code>aria-label</code>. This page will guide you through that process, but accessibility is a primary
+      <code>aria-label</code> (or corresponding styling classes). This page will guide you through that process, but accessibility is a primary
       goal of this project.
     </p>
 
@@ -610,6 +610,43 @@
             <div class="title-bar-controls">
               <button aria-label="Help"></button>
               <button aria-label="Close"></button>
+            </div>
+          </div>
+        `) %>
+
+        <p>
+          Each <code>aria-label</code> also has a corresponding styling class to render the title bar buttons,
+          to let the <code>aria-label</code> text be in other languages without causing rendering, accessibility, or localization issues.
+        </p>
+
+        <%- example(`
+          <div class="title-bar">
+            <div class="title-bar-text">A Title Bar using Button Styling Classes</div>
+            <div class="title-bar-controls">
+              <button class="minimize"></button>
+              <button class="maximize"></button>
+              <button class="close"></button>
+            </div>
+          </div>
+
+          <br />
+
+          <div class="title-bar">
+            <div class="title-bar-text">A Maximized Title Bar using Button Styling Classes</div>
+            <div class="title-bar-controls">
+              <button class="minimize"></button>
+              <button class="restore"></button>
+              <button class="close"></button>
+            </div>
+          </div>
+
+          <br />
+
+          <div class="title-bar">
+            <div class="title-bar-text">A Helpful Bar using Button Styling Classes</div>
+            <div class="title-bar-controls">
+              <button class="help"></button>
+              <button class="close"></button>
             </div>
           </div>
         `) %>

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -94,7 +94,7 @@
     <p>
       This library relies on the usage of <strong>semantic HTML</strong>. To make a button, you'll need
       to use a <code>&lt;button&gt;</code>. Input elements require labels. Icon buttons rely on
-      <code>aria-label</code> (or corresponding styling classes). This page will guide you through that process, but accessibility is a primary
+      <code>aria-label</code>. This page will guide you through that process, but accessibility is a primary
       goal of this project.
     </p>
 
@@ -623,9 +623,9 @@
           <div class="title-bar">
             <div class="title-bar-text">A Title Bar using Button Styling Classes</div>
             <div class="title-bar-controls">
-              <button class="minimize"></button>
-              <button class="maximize"></button>
-              <button class="close"></button>
+              <button aria-label="Any Text" class="minimize"></button>
+              <button aria-label="Any Text" class="maximize"></button>
+              <button aria-label="Any Text" class="close"></button>
             </div>
           </div>
 
@@ -634,9 +634,9 @@
           <div class="title-bar">
             <div class="title-bar-text">A Maximized Title Bar using Button Styling Classes</div>
             <div class="title-bar-controls">
-              <button class="minimize"></button>
-              <button class="restore"></button>
-              <button class="close"></button>
+              <button aria-label="Any Text" class="minimize"></button>
+              <button aria-label="Any Text" class="restore"></button>
+              <button aria-label="Any Text" class="close"></button>
             </div>
           </div>
 
@@ -645,8 +645,8 @@
           <div class="title-bar">
             <div class="title-bar-text">A Helpful Bar using Button Styling Classes</div>
             <div class="title-bar-controls">
-              <button class="help"></button>
-              <button class="close"></button>
+              <button aria-label="Any Text" class="help"></button>
+              <button aria-label="Any Text" class="close"></button>
             </div>
           </div>
         `) %>

--- a/style.css
+++ b/style.css
@@ -254,31 +254,36 @@ input[type="reset"]:disabled,
   outline: none;
 }
 
-.title-bar-controls button[aria-label="Minimize"] {
+.title-bar-controls button[aria-label="Minimize"],
+.title-bar-controls button.minimize {
   background-image: svg-load("./icon/minimize.svg");
   background-repeat: no-repeat;
   background-position: bottom 3px left 4px;
 }
 
-.title-bar-controls button[aria-label="Maximize"] {
+.title-bar-controls button[aria-label="Maximize"],
+.title-bar-controls button.maximize {
   background-image: svg-load("./icon/maximize.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 3px;
 }
 
-.title-bar-controls button[aria-label="Restore"] {
+.title-bar-controls button[aria-label="Restore"],
+.title-bar-controls button.restore {
   background-image: svg-load("./icon/restore.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 3px;
 }
 
-.title-bar-controls button[aria-label="Help"] {
+.title-bar-controls button[aria-label="Help"],
+.title-bar-controls button.help {
   background-image: svg-load("./icon/help.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 5px;
 }
 
-.title-bar-controls button[aria-label="Close"] {
+.title-bar-controls button[aria-label="Close"],
+.title-bar-controls button.close {
   margin-left: 2px;
   background-image: svg-load("./icon/close.svg");
   background-repeat: no-repeat;

--- a/style.css
+++ b/style.css
@@ -255,35 +255,35 @@ input[type="reset"]:disabled,
 }
 
 .title-bar-controls button[aria-label="Minimize"],
-.title-bar-controls button.minimize {
+.title-bar-controls button[aria-label].minimize {
   background-image: svg-load("./icon/minimize.svg");
   background-repeat: no-repeat;
   background-position: bottom 3px left 4px;
 }
 
 .title-bar-controls button[aria-label="Maximize"],
-.title-bar-controls button.maximize {
+.title-bar-controls button[aria-label].maximize {
   background-image: svg-load("./icon/maximize.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 3px;
 }
 
 .title-bar-controls button[aria-label="Restore"],
-.title-bar-controls button.restore {
+.title-bar-controls button[aria-label].restore {
   background-image: svg-load("./icon/restore.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 3px;
 }
 
 .title-bar-controls button[aria-label="Help"],
-.title-bar-controls button.help {
+.title-bar-controls button[aria-label].help {
   background-image: svg-load("./icon/help.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 5px;
 }
 
 .title-bar-controls button[aria-label="Close"],
-.title-bar-controls button.close {
+.title-bar-controls button[aria-label].close {
   margin-left: 2px;
   background-image: svg-load("./icon/close.svg");
   background-repeat: no-repeat;


### PR DESCRIPTION
Fixes #91

## In this PR:
- Added styling class alternatives for title bar buttons' `aria-label` styling selectors.
- Updated documentation to include example of styling class alternatives.

## 📈 Impact

Should this PR work as intended, users can now have title bar buttons' `aria-label`s be in languages other than English, such as the issue's example of using  `aria-label="Schließen"` for a Close button, without causing rendering, accessibility, or localization issues.

## 📔 Dev Note

I believe that having an example of `class` and `aria-label` being used together to show that you can render buttons without  completely relying on English text could be helpful. However, I did not know what would be the best way to do this in the documentation. I was thinking of using the issue's example with a window with only a close button, but I'm not certain. If this example seems good, I can add that to this PR. 