### PR TITLE
Add `disabled` styling for Maximize title bar buttons

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -613,6 +613,20 @@
             </div>
           </div>
         `) %>
+        <p>
+          Maximize buttons can be disabled, useful when making a window appear as if it cannot be maximized.
+        </p>
+
+        <%- example(`
+          <div class="title-bar">
+            <div class="title-bar-text">A Title Bar with Maximize disabled</div>
+            <div class="title-bar-controls">
+              <button aria-label="Minimize"></button>
+              <button aria-label="Maximize" disabled></button>
+              <button aria-label="Close"></button>
+            </div>
+          </div>
+        `) %>
 		<p>
           You can make a title bar "inactive" by adding <code>inactive</code> class,
 		  useful when making more than one window.

--- a/icon/maximize-disabled.svg
+++ b/icon/maximize-disabled.svg
@@ -1,0 +1,4 @@
+<svg width="10" height="10" viewBox="0 0 10 10" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M10 1H1V3V9V10H2H9H10V9V3V1ZM9 3H2V9H9V3Z" fill="white"/>
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M9 0H0V2V8V9H1H8H9V8V2V0ZM8 2H1V8H8V2Z" fill="#808080"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -266,6 +266,12 @@ input[type="reset"]:disabled,
   background-position: top 2px left 3px;
 }
 
+.title-bar-controls button[aria-label="Maximize"]:disabled {
+  background-image: svg-load("./icon/maximize-disabled.svg");
+  background-repeat: no-repeat;
+  background-position: top 2px left 3px;
+}
+
 .title-bar-controls button[aria-label="Restore"] {
   background-image: svg-load("./icon/restore.svg");
   background-repeat: no-repeat;

--- a/style.css
+++ b/style.css
@@ -267,7 +267,8 @@ input[type="reset"]:disabled,
   background-position: top 2px left 3px;
 }
 
-.title-bar-controls button[aria-label="Maximize"]:disabled {
+.title-bar-controls button[aria-label="Maximize"]:disabled,
+.title-bar-controls button[aria-label].maximize:disabled {
   background-image: svg-load("./icon/maximize-disabled.svg");
   background-repeat: no-repeat;
   background-position: top 2px left 3px;


### PR DESCRIPTION
## In this PR
- Added `icon/maximize-disabled.svg`, based on a disabled Maximize title bar button[^1].
- Added styling declaration for disabled Maximize buttons.
- Added documentation example of disabled Maximize buttons

## 📈 Impact

With this additions, users will be able to style windows as if they cannot be maximize. This can be useful when users wish to:
- recreate Windows 98 UIs, such as the Media Player or CD Player.
- replicate Windows 98 functionality in their project, such as having a window be able to be maximized.
- provide a visual aid that a window cannot be maximized.

<img width="880" alt="Screenshot 2024-01-21 at 12 36 33 PM" src="https://github.com/jdan/98.css/assets/15847889/8b292905-3a39-4d70-8ee6-8a5665b1438f">


## Reasons for Drafting this PR

I have another PR related to title bar buttons up (#189). As that PR could cause merge conflicts with this PR **and** has changes that, if approved, need to be applied to for disabled maximize buttons to work as intended without English-text `aria-label`s, this will be a draft until action is done on that PR.

This prevents a possible bug from arising if work is not done to apply the changes in #189 to this PR.

## 📔 Dev Note

I tried looking for examples of the remaining 4 title bar buttons having a disabled state, but couldn't find concrete evidence of that in Windows 98. 

[^1]: styling based on multimedia application UIs screenshots from this website: https://guidebookgallery.org/screenshots/win98