### PR TITLE
Removed `--checkmark-top` to fix multiline checkboxes

### DIFF
--- a/style.css
+++ b/style.css
@@ -45,7 +45,6 @@
   --checkbox-total-width: calc(var(--checkbox-total-width-precalc));
   --checkbox-left: calc(-1 * var(--checkbox-total-width-precalc));
   --checkmark-width: 7px;
-  --checkmark-top: 3px;
   --checkmark-left: 3px;
 
   /* Borders */
@@ -429,7 +428,6 @@ input[type="checkbox"]:checked + label::after {
   width: var(--checkmark-width);
   height: var(--checkmark-width);
   position: absolute;
-  top: var(--checkmark-top);
   left: calc(
     -1 * (var(--checkbox-total-width-precalc)) + var(--checkmark-left)
   );


### PR DESCRIPTION
Fixes #142

## In this PR:

- Removed `--checkmark-top` and related `top:...` code to fix multiline checkboxes[^1]

## 💭 Reasoning

As stated in #142, if a label was wrapped to be more than one line, the checkbox would be centered but not the checkmark.

![](https://user-images.githubusercontent.com/82685767/193435445-fd39c793-1e69-4eed-98a5-9005f9933629.png)[^2]

The source of this issue was due to `--checkmark-top` forcing a `top: 3px` onto the checkmark[^1], which seemed to worked as intended until the label became multiline. When disabled, however, the `top` declaration didn't seem to be doing anything to force the checkmark to appear in the right place.

<img width="781" alt="Screenshot 2024-01-22 at 5 13 41 PM" src="https://github.com/jdan/98.css/assets/15847889/edd70003-8fe6-41a5-8e69-397e50446d6c">

When removed, no visible changes occurred. 

## 📈 Impact

Should this PR be accepted, this should prevent a noticeable visual bug from occurring.

## 📔 Dev Note

Does anyone know what a multiline checkbox would look like in W98? Couldn't find any examples of that, nor have I been able to get a VM going with W98 to check.

[^1]: This fix was first reported by @psyklon-project [here](https://github.com/jdan/98.css/issues/142#issuecomment-1280738458)
[^2]: Image from @metropolis-nostalgia 