### PR TITLE
Add `default` button outline styling

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -141,7 +141,7 @@
           They are given 12px of horizontal padding by default.
         </p>
 
-        <%- example(`<button>Click me</button>
+        <%- example(`<button class="default">Click me</button>
         <input type="submit" />
         <input type="reset" /> `)%>
 

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -141,9 +141,17 @@
           They are given 12px of horizontal padding by default.
         </p>
 
-        <%- example(`<button class="default">Click me</button>
+        <%- example(`<button>Click me</button>
         <input type="submit" />
         <input type="reset" /> `)%>
+
+        <p>
+          You can add the class <code>default</code> to any button to apply additional styling, 
+          useful when communicating to the user what default action would happen in the active window if 
+          the <kbd>Enter</kbd> key was pressed on Windows 98.
+        </p>
+
+        <%- example(`<button class="default">OK</button>`)%>
 
         <p>
           When buttons are clicked, the raised borders become sunken.

--- a/style.css
+++ b/style.css
@@ -64,14 +64,6 @@
   --default-button-border-sunken-inner: inset -2px -2px var(--button-highlight), inset 3px 3px var(--button-shadow), inset -3px -3px var(--button-face);
 
 
-  .default {
-    box-shadow: var(--default-button-border-raised-outer), var(--default-button-border-raised-inner);
-  }
-  
-  .default:active {
-    box-shadow: var(--default-button-border-sunken-outer), var(--default-button-border-sunken-inner);
-  }
-
   /* Window borders flip button-face and button-highlight */
   --border-window-outer: inset -1px -1px var(--window-frame),
     inset 1px 1px var(--button-face);
@@ -166,6 +158,12 @@ input[type="reset"] {
   padding: 0 12px;
 }
 
+button.default,
+input[type="submit"].default,
+input[type="reset"].default {
+  box-shadow: var(--default-button-border-raised-outer), var(--default-button-border-raised-inner);
+}
+
 .vertical-bar {
   width: 4px;
   height: 20px;
@@ -178,6 +176,12 @@ input[type="submit"]:not(:disabled):active,
 input[type="reset"]:not(:disabled):active {
   box-shadow: var(--border-sunken-outer), var(--border-sunken-inner);
   text-shadow: 1px 1px var(--text-color);
+}
+
+button.default:not(:disabled):active,
+input[type="submit"].default:not(:disabled):active,
+input[type="reset"].default:not(:disabled):active {
+  box-shadow: var(--default-button-border-sunken-outer), var(--default-button-border-sunken-inner);
 }
 
 @media (not(hover)) {

--- a/style.css
+++ b/style.css
@@ -58,6 +58,19 @@
     inset 1px 1px var(--window-frame);
   --border-sunken-inner: inset -2px -2px var(--button-face),
     inset 2px 2px var(--button-shadow);
+  --default-button-border-raised-outer: inset -2px -2px var(--window-frame), inset 1px 1px var(--window-frame);
+  --default-button-border-raised-inner: inset 2px 2px var(--button-highlight), inset -3px -3px var(--button-shadow), inset 3px 3px var(--button-face);
+  --default-button-border-sunken-outer: inset 2px 2px var(--window-frame), inset -1px -1px var(--window-frame);
+  --default-button-border-sunken-inner: inset -2px -2px var(--button-highlight), inset 3px 3px var(--button-shadow), inset -3px -3px var(--button-face);
+
+
+  .default {
+    box-shadow: var(--default-button-border-raised-outer), var(--default-button-border-raised-inner);
+  }
+  
+  .default:active {
+    box-shadow: var(--default-button-border-sunken-outer), var(--default-button-border-sunken-inner);
+  }
 
   /* Window borders flip button-face and button-highlight */
   --border-window-outer: inset -1px -1px var(--window-frame),


### PR DESCRIPTION
## In this PR

- Added `default` styling to allow users to style buttons as "default" buttons on a dialog [^1]

## 💭 Reasoning

From all the Windows 98 UI examples I've seen, some have one button in the window with a darker outline.

![image](https://github.com/jdan/98.css/assets/15847889/aedba502-f4a1-4671-984c-32efabec1a01)

I decided to add a styling class that would allow users to style buttons to appear this way.

<img width="1319" alt="Screenshot 2024-01-22 at 6 16 04 PM" src="https://github.com/jdan/98.css/assets/15847889/13d6584f-26d6-475f-b452-01046e0d4e0a">

## 📈 Impact

Should this PR be approved and merged in, users of 98.css will be given another tool in recreating Windows 98 UIs or their personal projects. It's also one more step in replicating W98's UI.

[^1]: Class name taken [from this thread about 98.css](https://news.ycombinator.com/item?id=33310554)