### PR TITLE
Add mixed-value state styling to checkboxes

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -231,7 +231,7 @@
         `) %>
 
         <p>
-          Checkboxes can be displayed in a mixed-value, or <code>indeterminate</code>, appearance through JavaScript. This state can also be disabled.
+          Checkboxes can be displayed in a mixed-value, or <code>indeterminate</code>, state through JavaScript. This state can also be disabled.
         </p>
 
         <%- example(`

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -229,6 +229,27 @@
             <label for="example${getCurrentId()}">I am inactive but still checked</label>
           </div>
         `) %>
+
+        <p>
+          Checkboxes can be displayed in a mixed-value, or <code>indeterminate</code>, appearance through JavaScript. This state can also be disabled.
+        </p>
+
+        <%- example(`
+          <div class="field-row">
+            <input type="checkbox" id="indeterminate-example-1">
+            <label for="indeterminate-example">This is a mixed-value / indeterminate checkbox</label>
+          </div>
+          <div class="field-row">
+            <input type="checkbox" disabled id="indeterminate-example-2">
+            <label for="indeterminate-example">This is a disabled mixed-value / indeterminate checkbox</label>
+          </div>
+
+          <!-- JavaScript -->
+          <script>
+            document.getElementById("indeterminate-example-1").indeterminate = true;
+            document.getElementById("indeterminate-example-2").indeterminate = true;
+          </script>
+        `) %>
       </div>
     </section>
 

--- a/icon/checkmark-mixed-value-disabled.svg
+++ b/icon/checkmark-mixed-value-disabled.svg
@@ -1,0 +1,33 @@
+<svg width="7" height="7" viewBox="0 0 7 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 0h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 0h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 0h1v1h-1z" fill="#808080" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M1 1h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 1h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 1h1v1h-1z" fill="#808080" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 2h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 2h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 2h1v1h-1z" fill="#808080" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M1 3h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 3h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 3h1v1h-1z" fill="#808080" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 4h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 4h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 4h1v1h-1z" fill="#808080" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M1 5h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 5h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 5h1v1h-1z" fill="#808080" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 6h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 6h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 6h1v1h-1z" fill="#808080" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 6h1v1h-1z" fill="#808080" />
+</svg>

--- a/icon/checkmark-mixed-value.svg
+++ b/icon/checkmark-mixed-value.svg
@@ -1,0 +1,33 @@
+<svg width="7" height="7" viewBox="0 0 7 7" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 0h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 0h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 0h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 0h1v1h-1z" fill="black" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M1 1h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 1h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 1h1v1h-1z" fill="black" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 2h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 2h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 2h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 2h1v1h-1z" fill="black" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M1 3h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 3h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 3h1v1h-1z" fill="black" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 4h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 4h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 4h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 4h1v1h-1z" fill="black" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M1 5h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M3 5h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M5 5h1v1h-1z" fill="black" />
+
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M0 6h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M2 6h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M4 6h1v1h-1z" fill="black" />
+  <path fill-rule="evenodd" clip-rule="evenodd" d="M6 6h1v1h-1z" fill="black" />
+</svg>

--- a/style.css
+++ b/style.css
@@ -451,7 +451,8 @@ input[type="checkbox"]:active + label::before {
   background: var(--surface);
 }
 
-input[type="checkbox"]:checked + label::after {
+input[type="checkbox"]:checked + label::after,
+input[type="checkbox"]:indeterminate + label::after {
   content: "";
   display: block;
   width: var(--checkmark-width);
@@ -463,12 +464,20 @@ input[type="checkbox"]:checked + label::after {
   background: svg-load("./icon/checkmark.svg");
 }
 
+input[type="checkbox"]:indeterminate + label::after {
+  background: svg-load("./icon/checkmark-mixed-value.svg");
+}
+
 input[type="checkbox"][disabled] + label::before {
   background: var(--surface);
 }
 
 input[type="checkbox"][disabled]:checked + label::after {
   background: svg-load("./icon/checkmark-disabled.svg");
+}
+
+input[type="checkbox"][disabled]:indeterminate + label::after {
+  background: svg-load("./icon/checkmark-mixed-value-disabled.svg");
 }
 
 input[type="text"],


### PR DESCRIPTION
## In this PR
- Added `:indeterminate` pseudo-class selector for `input[type="checkbox"]`, including a `disabled` state.
- Added `checkbox-mixed-value.svg` and `checkbox-mixed-value-disabled.svg`[^1]

<img width="1076" alt="Screenshot 2024-04-27 at 7 56 00 AM" src="https://github.com/jdan/98.css/assets/15847889/60d619cf-67f1-41f2-b666-28d4ba33b68e">

## 💭 Reasoning

This state has been added to add additional styling present on pre-2000s Windows OSes, and to prevent browser default styling from occurring when a checkbox is set to `indeterminate`.

From [_The Windows Interface Guidelines — A Guide for Designing Software_](https://ics.uci.edu/~kobsa/courses/ICS104/course-notes/Microsoft_WindowsGuidelines.pdf), Chapter 7 ("Menus, Controls, and Toolbars"), page 143:

>If you use a check box to display the value for the property of a multiple selection whose values for that property
differ (for example, for a text selection that is partly bold), display the check box in its mixed-value appearance, a
checkerboard pattern inside the box, as shown in Figure 7.12. 

<img width="473" alt="Screenshot 2024-04-27 at 8 03 08 AM" src="https://github.com/jdan/98.css/assets/15847889/aa200bd0-cbd3-4321-935b-81ee88128257">

This further allows users of 98.css to style their HTML markup and/or applications to match Windows 98.

[^1]: Filenames chosen from Windows Interface Guidelines
