### PR TITLE
Added optional `::selection` styling for `.window-body` children

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -745,7 +745,6 @@
           To apply custom selection styling to children of a <code>window-body</code> element, you can add the optional <code>color-highlight</code> class. Note that overriding selection styling may impact <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::selection#accessibility_concerns">accessibility</a>, so use at your own discretion. 
         </p>
         
-
         <%- example(`
         <div class="window" style="width: 300px">
           <div class="title-bar">

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -740,6 +740,29 @@
             </div>
           </div>
         `) %>
+
+        <p>
+          To apply custom selection styling to children of a <code>window-body</code> element, you can add the optional <code>color-highlight</code> class. Note that overriding selection styling may impact <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/::selection#accessibility_concerns">accessibility</a>, so use at your own discretion. 
+        </p>
+        
+
+        <%- example(`
+        <div class="window" style="width: 300px">
+          <div class="title-bar">
+            <div class="title-bar-text">A Window With Stuff In It</div>
+            <div class="title-bar-controls">
+              <button aria-label="Minimize"></button>
+              <button aria-label="Maximize"></button>
+              <button aria-label="Close"></button>
+            </div>
+          </div>
+          <div class="window-body">
+            <p class="color-highlight">You can highlight me and a custom <code>::selection</code> styling will be present!</p>
+
+            <p> I have no custom <code>::selection</code> styling</p>
+          </div>
+        </div>
+      `) %>
       </div>
     </section>
 

--- a/style.css
+++ b/style.css
@@ -17,6 +17,8 @@
   --dialog-gray: #808080;
   --dialog-gray-light: #b5b5b5;
   --link-blue: #0000ff;
+  --highlight-blue: #00005e;
+  --text-highlight: #ffffff;
 
   /* Spacing */
   --element-spacing: 8px;
@@ -328,6 +330,12 @@ input[type="reset"]:disabled,
 
 .window-body {
   margin: var(--element-spacing);
+}
+
+.window-body .color-highlight::selection,
+.window-body .color-highlight *::selection {
+  color: var(--text-highlight);
+  background-color: var(--highlight-blue);
 }
 
 fieldset {


### PR DESCRIPTION
## In this PR
- Added an optional `color-highlight`[^1] class that can apply `::selection` styling based on Windows 98 text highlighting styling.[^1]

<img width="864" alt="Screenshot 2024-04-28 at 12 48 26 PM" src="https://github.com/jdan/98.css/assets/15847889/40e1bebe-b52e-4c74-b016-bb42bcf87817">

## 💭 Reasoning
Adding this styling can ensure that developers and designers can build a more authentic UI based on Windows 98, down to how text highlighting was styled.

## 📔 Dev Notes
The decision to make `::selection` styling apply thru an optional class was to ensure that a developer would have to consciously choose if they want an area to have W98 selection styling on an element, as there can be significant accessibility impacts[^2] if done. 

This also has the benefit of allowing a user of 98.css to choose when and where on a `window-body` element they want the custom highlight styling to occur, as the use of `text-shadow` with this custom highlight styling could make some highlights look off.

The foreground and background of this selection styling surpasses WCAG AA and AAA with a contrast ratio of **18.07**:1[^3].

[^1]: Name for class and styling sourced from [_Windows Interface Guidelines_, chapter 13 - Visual Design, page 325](https://ics.uci.edu/~kobsa/courses/ICS104/course-notes/Microsoft_WindowsGuidelines.pdf#page=306)
[^2]: https://developer.mozilla.org/en-US/docs/Web/CSS/::selection#accessibility_concerns
[^3]: https://webaim.org/resources/contrastchecker/?fcolor=FFFFFF&bcolor=00005E