### PR TITLE
Add input type number spinner styling

### DIFF
--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -439,6 +439,13 @@
           <label for="text${getNewId()}">Search</label>
           <input id="text${getCurrentId()}" type="search" value="98 css"/>
         </div>
+        <div class="number-input">
+          <input type="number" id="text${getNewId()}" min="1980" max="2099" value="1998">
+          <div class="number-input-controls">
+            <button aria-label="Up"></button>
+            <button aria-label="Down"></button>
+          </div>
+        </div>
       `) %>
 
       </div>

--- a/icon/input-control-down.svg
+++ b/icon/input-control-down.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="9" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M11 6H4V7H5V8H6V9H7V10H8V9H9V8H10V7H11V6Z" fill="black"/>
+</svg>

--- a/icon/input-control-up.svg
+++ b/icon/input-control-up.svg
@@ -1,0 +1,3 @@
+<svg width="8" height="9" viewBox="0 0 16 17" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M8 6H7V7H6V8H5V9H4V10H11V9H10V8H9V7H8V6Z" fill="black"/>
+</svg>

--- a/style.css
+++ b/style.css
@@ -494,14 +494,60 @@ input[type="text"],
 input[type="password"],
 input[type="email"],
 input[type="tel"],
+input[type="number"],
 input[type="search"],
 select {
   height: 21px;
 }
-input[type="number"] {
-  /* need this 1 pixel to fit the spinner controls in box */
-  height: 22px;
+
+.number-input {
+  display: flex;
+  gap: 1px;
 }
+
+.number-input-controls {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+}
+
+.number-input-controls button:focus {
+  outline: none;
+}
+
+.number-input-controls button[aria-label="Up"],
+.number-input-controls button[aria-label].up,
+.number-input-controls button[aria-label="Down"],
+.number-input-controls button[aria-label].down {
+    min-width: 15px;
+    min-height: 10px;
+    padding: 0;
+    background-repeat: no-repeat;
+    background-position: bottom;
+}
+
+.number-input-controls button[aria-label="Up"],
+.number-input-controls button[aria-label].up {
+    background-image: svg-load("./icon/input-control-up.svg");
+}
+
+.number-input-controls button[aria-label="Down"],
+.number-input-controls button[aria-label].down {
+    background-image: svg-load("./icon/input-control-down.svg");
+}
+
+input[type="number"] {
+    -webkit-appearance: textfield;
+    -moz-appearance: textfield;
+    appearance: textfield;
+    padding-right: 32px;
+}
+
+input[type="number"]::-webkit-inner-spin-button,
+input[type="number"]::-webkit-outer-spin-button {
+    -webkit-appearance: none;
+}
+
 /* clears the ‘X’ from Internet Explorer */
 input[type=search]::-ms-clear { display: none; width : 0; height: 0; }
 input[type=search]::-ms-reveal { display: none; width : 0; height: 0; }


### PR DESCRIPTION
- Added classes number-input and number-input-controls
- Added spinner styling for input type=number

> ![image](https://github.com/jdan/98.css/assets/156146842/824aaa3f-7c70-431d-8775-b9a8cc921747)

### Reference photo:

> ![image](https://github.com/jdan/98.css/assets/156146842/ec44b67b-da7e-4999-af36-34c2c7fe0378)

Setup is very similar to title-bar and title-bar-controls.