### PR TITLE
Disable text selection on form labels

### DIFF
--- a/style.css
+++ b/style.css
@@ -366,6 +366,7 @@ legend {
 label {
   display: inline-flex;
   align-items: center;
+  user-select: none;
 }
 
 input[type="radio"],


### PR DESCRIPTION
<img width="132" alt="Skärmavbild 2024-11-06 kl  08 43 17" src="https://github.com/user-attachments/assets/c273299d-550b-4900-b69c-55e23e390bb0">

When double-clicking on a form label it currently gets a text selection which can be confusing. This is not the Windows 98 behaviour. Fixed with this change.

