### PR TITLE
add combo boxes

### DIFF
--- a/docs/docs.css
+++ b/docs/docs.css
@@ -116,6 +116,24 @@ button.active {
     inset -2px -2px #dfdfdf, inset 2px 2px #808080;
 }
 
+ul[role=listbox] > li.last-hovered,
+.combo-box.key-nav > input[aria-haspopup] ~ ul > li[aria-selected=true] {
+  color: #fff;
+  background-color: #000080;
+}
+
+.combo-box.key-nav > ul[role=listbox] > li.last-hovered,
+.combo-box.key-nav > ul[role=listbox] > li:hover:not([aria-selected=true]) {
+  color: inherit;
+  background-color: inherit;
+}
+
+.combo-box > input[aria-haspopup] ~ ul:has(.last-hovered) > li[aria-selected=true]:not(.last-hovered),
+.combo-box:not(.key-nav) > input[aria-haspopup] ~ ul:has(.last-hovered) > li[aria-selected=true]:not(.last-hovered) {
+  color: inherit;
+  background-color: inherit;
+}
+
 @media (max-width: 480px) {
   aside {
     display: none;

--- a/docs/index.html.ejs
+++ b/docs/index.html.ejs
@@ -31,6 +31,7 @@
           <li><a href="#group-box">GroupBox</a></li>
           <li><a href="#text-box">TextBox</a></li>
           <li><a href="#slider">Slider</a></li>
+          <li><a href="#combo-box">ComboBox</a></li>
           <li><a href="#dropdown">Dropdown</a></li>
           <li>
             <a href="#window">Window</a>
@@ -461,6 +462,65 @@
             <div class="is-vertical">
               <input id="range${getCurrentId()}" class="has-box-indicator" type="range" min="1" max="3" step="1" value="2" />
             </div>
+          </div>
+        `) %>
+      </div>
+    </section>
+
+    <section class="component">
+      <h3 id="combo-box">ComboBox</h3>
+      <div>
+        <blockquote>
+          A <em>combo box</em> combines a text box with a list box. This allows the user to type an entry or choose one from the list.
+
+          <footer>
+            &mdash; Microsoft Windows User Experience p. 183
+          </footer>
+        </blockquote>
+
+        <p>
+          There are 2 ways you can render a combo box. The first is using a text <code>input</code>, a parent <code>ul</code>, and children <code>li</code> together, wrapped inside a container element with the <code>combo-box</code> class. For accessibility, follow the minimum requirements below: 
+        </p>
+
+        <ul>
+          <li>Add a <code>role="combobox"</code> attribute to the text <code>input</code></li>
+          <li>Add a <code>role="listbox"</code> attribute to the <code>ul</code></li>
+          <li>Add a <code>role="option"</code> attribute to each <code>li</code></li>
+          <li>
+            Specify the relationship between the list box and the text box by combining the <code>id</code> of the <code>listbox</code> with the <code>aria-controls</code> attribute on the text <code>input</code>
+          </li>
+        </ul>
+
+        <%- example(`
+          <div class="combo-box">
+            <input type="text" role="combobox" value="Regular" aria-controls="example${getNewId()}" />
+            <ul role="listbox" id="example${getCurrentId()}" tabindex="-1">
+              <li role="option" aria-selected="true">Regular</li>
+              <li role="option">Italic</li>
+              <li role="option">Bold</li>
+              <li role="option">Bold Italic</li>
+            </ul>
+          </div>
+        `) %>
+
+        <p>
+          The second adds a <code>button</code> to toggle the visibility of the drop-down. For accessibility, follow these additional requirements:
+        </p>
+
+        <ul>
+          <li>Add <code>aria-haspopup="listbox"</code> and <code>aria-expanded</code> attributes to the text <code>input</code></li>
+        </ul>
+
+        <%- example(`
+          <div class="combo-box" width="200px">
+            <input type="text" role="combobox" aria-haspopup="listbox" aria-expanded="false" aria-controls="example${getNewId()}" />
+            <button type="button" tabindex="-1"></button>
+            <ul role="listbox" id="example${getCurrentId()}" tabindex="-1">
+              <li role="option">h:mm:ss tt</li>
+              <li role="option">hh:mm:ss tt</li>
+              <li role="option">H:mm:ss</li>
+              <li role="option">HH:mm:ss</li>
+            </ul>
           </div>
         `) %>
       </div>
@@ -1126,4 +1186,5 @@
     </p>
   </main>
 </body>
+<script src="script.js"></script>
 </html>

--- a/docs/script.js
+++ b/docs/script.js
@@ -1,0 +1,98 @@
+// Combo Box
+document.querySelectorAll('.combo-box').forEach(combobox => {
+    const input = combobox.querySelector('input');
+    const listbox = combobox.querySelector('ul');
+    const options = Array.from(listbox.querySelectorAll('li'));
+    let currentIndex = findIndex();
+    let lastHovered = null;
+
+    function findIndex() {
+        return options.findIndex(option => option.getAttribute('aria-selected') === "true");
+    }
+
+    function scroll(block) {
+        const index = currentIndex === -1 ? 0 : currentIndex;
+        options[index].scrollIntoView({ block, behavior: "instant"});
+    }
+
+    function updateSelected(value = null) {
+        if (value !== null) input.value = value;
+        options.forEach(option => {
+            option.setAttribute('aria-selected', option.textContent.trim() === input.value.trim() ? 'true' : 'false');
+        });
+        currentIndex = findIndex();
+        if (currentIndex !== -1) scroll('nearest');
+    }
+    
+    function removeHovered() {
+        lastHovered?.classList.remove('last-hovered');
+        lastHovered = null;
+    }
+
+    function keyNavigate() {
+        combobox.classList.add('key-nav');
+        if (lastHovered) currentIndex = options.indexOf(lastHovered);
+        removeHovered();
+    }
+
+    function toggleDropdown() {
+        const isOpen = input.getAttribute('aria-expanded') === "true";
+        input.setAttribute('aria-expanded', isOpen ? 'false' : 'true');
+        input.focus();
+        !isOpen ? (currentIndex = findIndex(), scroll('nearest')) : removeHovered();
+    }
+
+    function navigationHandler(event) {
+        if (event.altKey && (event.key === "ArrowDown" || event.key === "ArrowUp") && input.hasAttribute('aria-haspopup')) {
+            event.preventDefault();
+            toggleDropdown();
+        } else if ((event.key === "ArrowDown" && currentIndex < options.length - 1) || (event.key === "ArrowUp" && currentIndex > 0)) {
+            event.preventDefault();
+            keyNavigate();
+            currentIndex += event.key === "ArrowDown" ? 1 : -1;
+            updateSelected(options[currentIndex].textContent);
+        } else if (event.key === "Enter" && input.hasAttribute('aria-haspopup') && input.getAttribute('aria-expanded') === "true") {
+            event.preventDefault();
+            updateSelected(lastHovered ? lastHovered.textContent : null);
+            toggleDropdown();
+        }
+    }
+
+    listbox.addEventListener('click', (event) => {
+        if (event.target.tagName === "LI") {
+            updateSelected(event.target.textContent);
+            if (input.hasAttribute('aria-haspopup')) toggleDropdown();
+        }
+    });
+
+    listbox.addEventListener('mousedown', (event) => {
+        event.preventDefault();
+        input.focus();
+    });
+
+    listbox.addEventListener('mousemove', () => combobox.classList.remove('key-nav'));
+
+    if (input.hasAttribute('aria-haspopup')) {
+        const button = combobox.querySelector('button');
+
+        listbox.addEventListener('mouseover', (event) => {
+            if (!combobox.classList.contains('key-nav') && event.target.tagName === "LI") {
+                removeHovered();
+                lastHovered = event.target;
+                lastHovered.classList.add('last-hovered');
+            }
+        });
+
+        button.addEventListener('click', () => toggleDropdown());
+        input.addEventListener('blur', () => {
+            if (input.getAttribute('aria-expanded') === "true") {
+                setTimeout(() => {
+                    if (document.activeElement !== input && document.activeElement !== button) toggleDropdown();
+                }, 0);
+            }
+        });
+    }
+
+    input.addEventListener('input', () => updateSelected(input.value));
+    input.addEventListener('keydown', navigationHandler);
+});

--- a/style.css
+++ b/style.css
@@ -112,6 +112,7 @@ textarea,
 select,
 option,
 table,
+.combo-box,
 ul.tree-view,
 .window,
 .title-bar,
@@ -688,6 +689,98 @@ select:focus option {
 
 select:active {
   background-image: svg-load("./icon/button-down-active.svg");
+}
+
+.combo-box {
+  display: inline-block;
+}
+
+.combo-box > ul {
+  background: #fff;
+  border: 2px groove transparent;
+  border-image: svg-load('./icon/sunken-panel-border.svg') 2;
+  box-sizing: border-box;
+  overflow-y: scroll;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.combo-box > ul:focus-within {
+  outline: none;
+}
+
+.combo-box > ul > li {
+  padding: 0 4px;
+  color: var(--text-color);
+}
+
+ul[role=listbox] > li[aria-selected=true],
+.combo-box > input[aria-haspopup] ~ ul > li:hover {
+  color: #fff;
+  background-color: var(--dialog-blue);
+}
+
+.combo-box > input[aria-haspopup] ~ ul:hover > li[aria-selected=true]:not(:hover) {
+  color: inherit;
+  background-color: inherit;
+}
+
+.combo-box.drop-down,
+.combo-box:has(input[aria-haspopup]) {
+  position: relative;
+  box-shadow: var(--border-field);
+  display: inline-flex;
+  padding: 2px;
+}
+
+.combo-box > input[aria-haspopup] {
+  height: 17px;
+  box-shadow: none;
+}
+
+.combo-box > button {
+  width: 16px;
+  height: 17px;
+  background-image: svg-load("./icon/button-down.svg");
+  background-repeat: no-repeat;
+  min-width: unset;
+  min-height: unset;
+  box-shadow: none;
+  padding: 0;
+}
+
+.combo-box > button:focus {
+  outline: none;
+  outline-offset: 0;
+}
+
+.combo-box > button:active {
+  box-shadow: none;
+}
+
+.combo-box > input[aria-expanded=false] + button:active {
+  background-image: svg-load("./icon/button-down-active.svg");
+}
+
+.combo-box > input[aria-haspopup] ~ ul {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  width: 100%;
+  border: 1px solid #000;
+  overflow-y: auto;
+}
+
+.combo-box > input[aria-expanded=true] ~ ul {
+  display: block;
+}
+
+.combo-box > ul,
+.combo-box > input:not([aria-haspopup]),
+.combo-box > input[aria-expanded=true] {
+  cursor: default;
 }
 
 a {


### PR DESCRIPTION
### Added Combo Boxes

- **Two Versions:** Regular and Drop-down
- Uses the `:has` selector. If preferred, a `.drop-down` class can be added alongside `.combo-box` for compatibility.
- Added a script to the documentation site for accessibility examples.
- Combo boxes are custom components, not native HTML elements, so they require some JavaScript for functionality. Most of the script handles miscellaneous behavior.
- Started work on list boxes as well. Planning to complete them soon.

![example](https://github.com/user-attachments/assets/bd8242c0-cf6c-4acf-bfbd-71a4bfe8fb1a)
